### PR TITLE
Fixes to make it work with recent versions of Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # Top-level Rakefile which is responsible for running all the other Rakefiles.
 
 # TODO: Uncomment the rest here as soon as we have merged their build process to rake also.
-folders = [ :storm, :libraries, :servers ]#, :programs ]
+folders = [:storm, :libraries, :servers]#, :programs]
 
 verbose false
 
@@ -9,7 +9,7 @@ root = pwd()
 
 # Need to set this up using a fully qualified path name, since the Rakefiles in the subfolders won't be able to find the custom
 # .rake files otherwise.
-Rake.application.options.rakelib = "#{root}/rakelib"
+Rake.application.options.rakelib = ["#{root}/rakelib"]
 
 desc "Compiles chaos"
 task :default => folders

--- a/libraries/Rakefile
+++ b/libraries/Rakefile
@@ -1,4 +1,4 @@
-Rake.application.options.rakelib = pwd + "/../rakelib" if Rake.application.options.rakelib.first == 'rakelib'
+Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 libraries = %w(
   console

--- a/libraries/libraries.rake
+++ b/libraries/libraries.rake
@@ -1,6 +1,6 @@
 # Common settings and Rake rules for all libraries.
 
-Rake.application.options.rakelib = "#{File.dirname(__FILE__)}/../rakelib" if Rake.application.options.rakelib.first == 'rakelib'
+Rake.application.options.rakelib = ["#{File.dirname(__FILE__)}/../rakelib"] if Rake.application.options.rakelib.first == 'rakelib'
 
 load "#{File.dirname(__FILE__)}/constants.rake"
 
@@ -35,4 +35,4 @@ end
 
 # The libraries aren't really "installed", but we need to support this target anyway so that you can run a top-level
 # "rake install" to get it all installed.
-task :install 
+task :install

--- a/servers/Rakefile
+++ b/servers/Rakefile
@@ -1,4 +1,4 @@
-Rake.application.options.rakelib = pwd + "/../rakelib" if Rake.application.options.rakelib.first == 'rakelib'
+Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
   system

--- a/servers/servers.rake
+++ b/servers/servers.rake
@@ -1,11 +1,11 @@
 # Common settings and Rake rules for all libraries.
 
-Rake.application.options.rakelib = "#{File.dirname(__FILE__)}/../rakelib" if Rake.application.options.rakelib.first == 'rakelib'
+Rake.application.options.rakelib = ["#{File.dirname(__FILE__)}/../rakelib"] if Rake.application.options.rakelib.first == 'rakelib'
 
 LIBRARIES_DIR = "#{File.dirname(__FILE__)}/../libraries"
 
 COMMON_CFLAGS = %w(
-  -Wall -Wextra -Wshadow -Wpointer-arith -Waggregate-return -Wredundant-decls -Winline -Werror -Wcast-align -Wsign-compare 
+  -Wall -Wextra -Wshadow -Wpointer-arith -Waggregate-return -Wredundant-decls -Winline -Werror -Wcast-align -Wsign-compare
   -Wmissing-declarations -Wmissing-noreturn -pipe -O3 -fno-builtin -funsigned-char -g -m32 -fomit-frame-pointer -ffreestanding
  )
 

--- a/servers/system/Rakefile
+++ b/servers/system/Rakefile
@@ -1,7 +1,7 @@
-Rake.application.options.rakelib = pwd + "/../../rakelib" if Rake.application.options.rakelib.first == 'rakelib'
+Rake.application.options.rakelib = [pwd + '/../../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
-  console  
+  console
 )
 
 # Not yet converted to Rake:

--- a/servers/video/Rakefile
+++ b/servers/video/Rakefile
@@ -1,4 +1,4 @@
-Rake.application.options.rakelib = pwd + "/../../rakelib" if Rake.application.options.rakelib.first == 'rakelib'
+Rake.application.options.rakelib = [pwd + '/../../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
   vga

--- a/storm/Rakefile
+++ b/storm/Rakefile
@@ -1,4 +1,4 @@
-Rake.application.options.rakelib = pwd + "/../rakelib" if Rake.application.options.rakelib.first == 'rakelib'
+Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 task :default => [ 'current-arch', 'include/storm/current-arch' ] do
   [ 'generic', 'current-arch' ].each do |folder|


### PR DESCRIPTION
`Rake.application.options.rakelib` must now be treated as an array. Previous versions of Rake was more forgiving, accepting it being used as a string rather than an array. But version 10.3.2 demands this.