### PR TITLE
Added Vagrantfile and use mtools for copying stuff into the floppy image

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Top-level Rakefile which is responsible for running all the other Rakefiles.
 
-# TODO: Uncomment the rest here as soon as we have merged their build process to rake also.
+# TODO: Uncomment the rest here as soon as we have updated their build process to rake also.
 folders = [:storm, :libraries, :servers]#, :programs]
 
 verbose false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,8 @@ Vagrant.configure(2) do |config|
   config.vm.box = "chef/debian-7.8"
   config.vm.provision 'shell', inline: <<-SHELL
      sudo apt-get update
-     sudo apt-get install -y g++ git nasm rake
+     sudo apt-get install -y g++ git mtools nasm rake
      echo 'cd /vagrant' >> /home/vagrant/.bashrc
+     echo 'drive a: file="/vagrant/floppy.img" 1.44m mformat_only' > /etc/mtools.conf
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,8 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "chef/debian-7.8"
+  config.vm.provision 'shell', inline: <<-SHELL
+     sudo apt-get update
+     sudo apt-get install -y g++ git nasm rake
+     echo 'cd /vagrant' >> /home/vagrant/.bashrc
+  SHELL
+end

--- a/rakelib/common_settings.rake
+++ b/rakelib/common_settings.rake
@@ -20,4 +20,5 @@ NASM = 'nasm'
 
 TARGET_ARCH = 'ia32'
 RAKE_COMMAND = "rake -s -N -R #{Rake.application.options.rakelib.first}"
-INSTALL_ROOT = '/Volumes/chaos'
+INSTALL_ROOT = 'a:'
+INSTALL_COMMAND = 'mcopy -D o'

--- a/servers/servers.rake
+++ b/servers/servers.rake
@@ -65,7 +65,6 @@ end
 task :install => OUTPUT do
   target_path = INSTALL_ROOT + '/servers'
 
-  sh "install -d #{target_path}"
-  sh "install #{OUTPUT} #{target_path}"
+  sh "#{INSTALL_COMMAND} #{OUTPUT} #{target_path}"
   puts "    Installed #{OUTPUT} in #{target_path}".gray
 end

--- a/storm/ia32/Rakefile
+++ b/storm/ia32/Rakefile
@@ -47,7 +47,7 @@ task :banner do
 end
 
 task :install do
-  sh "install #{KERNEL_OUTPUT} #{INSTALL_ROOT}"
+  sh "#{INSTALL_COMMAND} #{KERNEL_OUTPUT} #{INSTALL_ROOT}"
   puts "    Installed #{KERNEL_OUTPUT} in #{INSTALL_ROOT}".gray
 end
 


### PR DESCRIPTION
This is so we can more easily develop stuff on non-Linux machines (Mac, Windows etc.). Everyone else seems to be using Vagrant so why should we not? :smile: 