### PR TITLE
Removed g++ remnants

### DIFF
--- a/rakelib/common_rules.rake
+++ b/rakelib/common_rules.rake
@@ -9,17 +9,6 @@ rule '.o' => [ '.c' ] do |t|
   end
 end
 
-rule '.o' => [ '.cc' ] do |t|
-  begin
-    print((t.source + ' ').cyan)
-    command = "#{CC} -o #{t.name} #{CCFLAGS} #{INCLUDES.join(' ')} -c #{t.source}"
-    sh command
-  rescue
-    puts "Error compiling #{t.source}. Full command line was: #{command}"
-    raise
-  end
-end
-
 rule '.o' => [ '.S' ] do |t|
   begin
     print((t.source + ' ').cyan)

--- a/servers/servers.rake
+++ b/servers/servers.rake
@@ -35,10 +35,6 @@ CFLAGS = (COMMON_CFLAGS + %w(
   -Wnested-externs
   -Wstrict-prototypes
 )).join(' ')
-CCFLAGS = (COMMON_CFLAGS + %w(
-  --std=gnu++11
-  -Wno-inline
-)).join(' ')
 
 LDFLAGS = %W(
   #{LIBRARIES_DIR}/startup.o

--- a/storm/storm.rake
+++ b/storm/storm.rake
@@ -9,7 +9,6 @@ COMMON_CFLAGS =
 CFLAGS = COMMON_CFLAGS + 
 "--std=gnu99 -Wbad-function-cast -Wmissing-prototypes -Wnested-externs \
 -Wstrict-prototypes"
-CCFLAGS = COMMON_CFLAGS + "--std=gnu++11 " #-Wno-c++0x-compat"
 
 INCLUDES = %w(
   -I../include


### PR DESCRIPTION
Since we don't rely on `g++` any more, these should be gone in line with the KISS principle. No need to keep dead stuff there just because we "might" need it sometime. If it isn't being used, it must die!