### PR TITLE
Changed thread_create() to take the new thread entry point as parameter

### DIFF
--- a/grub.cfg
+++ b/grub.cfg
@@ -4,7 +4,7 @@ title chaos
 rootnoverify (fd0)
 kernel /storm
 module /servers/console
-#module /servers/keyboard
+module /servers/keyboard
 module /servers/vga
 #module /servers/log
 #module /servers/boot

--- a/libraries/console/console.c
+++ b/libraries/console/console.c
@@ -1,7 +1,9 @@
 // Abstract: Console library.
 // Author: Per Lundberg <per@halleluja.nu>
 //
-// © Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 // See The chaos Programming Reference Manual for more information about the functions in this library.
 

--- a/libraries/console/functions.h
+++ b/libraries/console/functions.h
@@ -1,7 +1,9 @@
 // Abstract: Function definitions for the console library.
 // Author: Per Lundberg <per@halleluja.nu>
 //
-// © Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/libraries/console/functions.h
+++ b/libraries/console/functions.h
@@ -12,9 +12,9 @@ C_EXTERN_BEGIN
 
 extern return_type console_init(console_structure_type *console_structure, tag_type *tag, unsigned int connection_class);
 extern return_type console_open(console_structure_type *console_structure, unsigned int width, unsigned int height,
-  unsigned int depth, int mode_type);
+                                unsigned int depth, int mode_type);
 extern return_type console_mode_set(console_structure_type *console_structure, unsigned int width, unsigned int height,
-  unsigned int depth, int mode_type);
+                                    unsigned int depth, int mode_type);
 
 extern return_type console_resize(console_structure_type *console_structure, unsigned int width, unsigned int height);
 extern return_type console_print(console_structure_type *console_structure, const char *string);

--- a/libraries/system/functions.h
+++ b/libraries/system/functions.h
@@ -19,7 +19,7 @@ extern return_type system_process_name_set(const char *name);
 extern void system_shutdown(void) NORETURN;
 extern return_type system_sleep(unsigned int time);
 extern return_type system_sleep_microseconds(unsigned int time);
-extern return_type system_thread_create(void);
+extern return_type system_thread_create(void *(*start_routine)(void *), void *argument);
 extern return_type system_thread_name_set(const char *name);
 
 C_EXTERN_END

--- a/libraries/system/functions.h
+++ b/libraries/system/functions.h
@@ -1,7 +1,10 @@
 // Abstract: Function prototypes.
 // Author: Per Lundberg <per@halleluja.nu>
 //
-// © Copyright 2000, 2007, 2013 chaos development.
+// © Copyright 2000 chaos development
+// © Copyright 2007 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/libraries/system/functions.h
+++ b/libraries/system/functions.h
@@ -19,7 +19,7 @@ extern return_type system_process_name_set(const char *name);
 extern void system_shutdown(void) NORETURN;
 extern return_type system_sleep(unsigned int time);
 extern return_type system_sleep_microseconds(unsigned int time);
-extern return_type system_thread_create(void *(*start_routine)(void *), void *argument);
+extern return_type system_thread_create(thread_entry_point_type *thread_entry_point, void *argument);
 extern return_type system_thread_name_set(const char *name);
 
 C_EXTERN_END

--- a/libraries/system/return_values.h
+++ b/libraries/system/return_values.h
@@ -1,26 +1,10 @@
-/* $Id$ */
-/* Abstract: Return values used by the system library. */
-/* Author: Per Lundberg <per@halleluja.nu> */
+// Abstract: Return values used by the system library.
+// Author: Per Lundberg <per@halleluja.nu>
+//
+// © Copyright 2000 chaos development
+// © Copyright 2015 chaos development
 
-/* Copyright 2000 chaos development. */
-
-/* This library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public License
-   as published by the Free Software Foundation; either version 2 of
-   the License, or (at your option) any later version.
-
-   This library is distributed in the hope that it will be useful, but
-   WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Lesser General Public License for more details.
-
-   You should have received a copy of the GNU Lesser General Public
-   License along with this library; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-   USA. */
-
-#ifndef __LIBRARY_SYSTEM_RETURN_VALUES_H__
-#define __LIBRARY_SYSTEM_RETURN_VALUES_H__
+#pragma once
 
 enum
 {
@@ -39,5 +23,3 @@ enum
 
   SYSTEM_RETURN_THREAD_CREATE_FAILED,
 };
-
-#endif /* !__LIBRARY_SYSTEM_RETURN_VALUES_H__ */

--- a/libraries/system/return_values.h
+++ b/libraries/system/return_values.h
@@ -8,18 +8,9 @@
 
 enum
 {
-  /* The call completed successfully. */
+    // The call completed successfully.
+    SYSTEM_RETURN_SUCCESS,
 
-  SYSTEM_RETURN_SUCCESS,
-
-  /* Those are returned by system_thread_create (), so that the caller
-     knows how to distinguish between the old and the new thread. */
-
-  SYSTEM_RETURN_THREAD_NEW,
-  SYSTEM_RETURN_THREAD_OLD,
-
-  /* Something went wrong in system_call_thread_create (), and we do
-     not yet handle it properly. Please fix. */
-
-  SYSTEM_RETURN_THREAD_CREATE_FAILED,
+    // Something went wrong in system_call_thread_create (), and we do not yet handle it properly. Please fix.
+    SYSTEM_RETURN_THREAD_CREATE_FAILED,
 };

--- a/libraries/system/system.c
+++ b/libraries/system/system.c
@@ -1,7 +1,10 @@
 // Abstract: Library for system related stuff.
 // Author: Per Lundberg <per@halleluja.nu>
 //
-// © Copyright 2000, 2007, 2013 chaos development.
+// © Copyright 2000 chaos development
+// © Copyright 2007 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #include <system/system.h>
 

--- a/libraries/system/system.c
+++ b/libraries/system/system.c
@@ -71,9 +71,9 @@ return_type system_thread_name_set(const char *name)
     return SYSTEM_RETURN_SUCCESS;
 }
 
-return_type system_thread_create(void *(*start_routine)(void *), void *argument)
+return_type system_thread_create(thread_entry_point_type *thread_entry_point, void *argument)
 {
-    switch(system_call_thread_create(start_routine, argument))
+    switch (system_call_thread_create(thread_entry_point, argument))
     {
         case STORM_RETURN_SUCCESS:
         {

--- a/libraries/system/system.c
+++ b/libraries/system/system.c
@@ -71,18 +71,13 @@ return_type system_thread_name_set(const char *name)
     return SYSTEM_RETURN_SUCCESS;
 }
 
-return_type system_thread_create(void)
+return_type system_thread_create(void *(*start_routine)(void *), void *argument)
 {
-    switch (system_call_thread_create())
+    switch(system_call_thread_create(start_routine, argument))
     {
-        case STORM_RETURN_THREAD_NEW:
+        case STORM_RETURN_SUCCESS:
         {
-            return SYSTEM_RETURN_THREAD_NEW;
-        }
-
-        case STORM_RETURN_THREAD_OLD:
-        {
-            return SYSTEM_RETURN_THREAD_OLD;
+            return SYSTEM_RETURN_SUCCESS;
         }
 
         // Someone has added a return code in thread.c in the kernel without handling it in the system library. Please fix this in

--- a/libraries/system/system_calls.h
+++ b/libraries/system/system_calls.h
@@ -220,13 +220,17 @@ static inline return_type system_call_thread_control(thread_id_type thread_id, u
 }
 
 // fork() on steroids. ;-)
-static inline return_type system_call_thread_create(void)
+static inline return_type system_call_thread_create(void *(*start_routine)(void *), void *argument)
 {
     return_type return_value;
 
-    asm volatile("lcall %1, $0"
+    asm volatile("pushl %1\n"
+                 "pushl %2\n"
+                 "lcall %3, $0"
                  : "=a" (return_value)
-                 : "n" (SYSTEM_CALL_THREAD_CREATE << 3));
+                 : "ri" (start_routine),
+                   "ri" (argument),
+                   "n" (SYSTEM_CALL_THREAD_CREATE << 3));
 
     return return_value;
 }

--- a/libraries/system/system_calls.h
+++ b/libraries/system/system_calls.h
@@ -2,7 +2,10 @@
 // Authors: Henrik Hallin <hal@chaosdev.org>,
 //          Per Lundberg <per@halleluja.nu>
 //
-// © Copyright 1999-2000, 2007, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2007 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/libraries/system/system_calls.h
+++ b/libraries/system/system_calls.h
@@ -228,8 +228,8 @@ static inline return_type system_call_thread_create(thread_entry_point_type *thr
                  "pushl %2\n"
                  "lcall %3, $0"
                  : "=a" (return_value)
-                 : "ri" (thread_entry_point),
-                   "ri" (argument),
+                 : "ri" (argument),
+                   "ri" (thread_entry_point),
                    "n" (SYSTEM_CALL_THREAD_CREATE << 3));
 
     return return_value;

--- a/libraries/system/system_calls.h
+++ b/libraries/system/system_calls.h
@@ -11,6 +11,9 @@
 
 #include <storm/storm.h>
 
+// TODO: Should consider automatically creating this file in system_calls.rb. It feels stupid to have to maintain this manually.
+// The difficult part is the asm constraints though, can be a bit tricky...
+
 // Inlines through New York can be dangerous -- so please use a helmet!
 static inline return_type system_call_init(void)
 {

--- a/libraries/system/system_calls.h
+++ b/libraries/system/system_calls.h
@@ -220,7 +220,7 @@ static inline return_type system_call_thread_control(thread_id_type thread_id, u
 }
 
 // fork() on steroids. ;-)
-static inline return_type system_call_thread_create(void *(*start_routine)(void *), void *argument)
+static inline return_type system_call_thread_create(thread_entry_point_type *thread_entry_point, void *argument)
 {
     return_type return_value;
 
@@ -228,7 +228,7 @@ static inline return_type system_call_thread_create(void *(*start_routine)(void 
                  "pushl %2\n"
                  "lcall %3, $0"
                  : "=a" (return_value)
-                 : "ri" (start_routine),
+                 : "ri" (thread_entry_point),
                    "ri" (argument),
                    "n" (SYSTEM_CALL_THREAD_CREATE << 3));
 

--- a/servers/system/console/connection.c
+++ b/servers/system/console/connection.c
@@ -340,8 +340,10 @@ static void connection_provider_mouse(message_parameter_type *message_parameter)
 }
 
 // Handle an IPC connection request.
-void handle_connection(mailbox_id_type reply_mailbox_id)
+void handle_connection(mailbox_id_type *reply_mailbox_id)
 {
+    system_thread_name_set("Handling connection");
+
     u32 *data;
     u32 **data_pointer = &data;
     message_parameter_type message_parameter;
@@ -356,7 +358,7 @@ void handle_connection(mailbox_id_type reply_mailbox_id)
     memory_allocate((void **) our_application_pointer, sizeof(console_application_type));
 
     // Accept the connection.
-    ipc_structure.output_mailbox_id = reply_mailbox_id;
+    ipc_structure.output_mailbox_id = *reply_mailbox_id;
     ipc_connection_establish(&ipc_structure);
 
     message_parameter.data = data;

--- a/servers/system/console/connection.c
+++ b/servers/system/console/connection.c
@@ -1,7 +1,10 @@
 // Abstract: Connection handling in the land of Oz.
 // Author: Per Lundberg <per@halleluja.nu>
 //
-// © Copyright 2000, 2007, 2013 chaos development.
+// © Copyright 2000 chaos development
+// © Copyright 2007 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #include <memory/memory.h>
 #include <video/video.h>

--- a/servers/system/console/console.c
+++ b/servers/system/console/console.c
@@ -143,10 +143,8 @@ int main(void)
 
     while (TRUE)
     {
-        mailbox_id_type reply_mailbox_id;
-
         ipc_service_connection_wait(&ipc_structure);
-        reply_mailbox_id = ipc_structure.output_mailbox_id;
+        mailbox_id_type reply_mailbox_id = ipc_structure.output_mailbox_id;
 
         system_thread_create((thread_entry_point_type *) handle_connection, &reply_mailbox_id);
     }

--- a/servers/system/console/console.c
+++ b/servers/system/console/console.c
@@ -148,10 +148,6 @@ int main(void)
         ipc_service_connection_wait(&ipc_structure);
         reply_mailbox_id = ipc_structure.output_mailbox_id;
 
-        if (system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
-        {
-            system_thread_name_set("Handling connection");
-            handle_connection(reply_mailbox_id);
-        }
+        system_thread_create((thread_entry_point_type *) handle_connection, &reply_mailbox_id);
     }
 }

--- a/servers/system/console/console.h
+++ b/servers/system/console/console.h
@@ -123,6 +123,6 @@ extern volatile unsigned int number_of_consoles;
 extern console_type *console_list;
 extern volatile console_type *console_shortcut[];
 
-extern void handle_connection(mailbox_id_type reply_mailbox_id) NORETURN;
+extern void handle_connection(mailbox_id_type *reply_mailbox_id) NORETURN;
 extern void console_link(console_type *console);
 extern void console_flip(console_type *console);

--- a/servers/system/keyboard/README
+++ b/servers/system/keyboard/README
@@ -16,4 +16,12 @@ keyboard servers both have to register a service of protocol
 "keyboard", but the first one will be /services/keyboard/0 and the
 second one will be /services/keyboard/1.
 
+Because a lot of this code is based on the GPL:ed Linux kernel (which
+you can see very quickly by browsing through e.g. keyboard.c), the server
+can only be legally used under the terms of the GPL. Our own parts are of
+course more liberally usable than so, but because of the intermingling here
+it is probably safest to just assume the whole server is GPL:ed. If you want
+to rewrite it all in pure, BSD-based goodness, please be our guest - pull
+requests are certainly welcome here.
+
 -- Per Lundberg <per@halleluja.nu>  Sat,  8 Jul 2000 02:48:28 +0200

--- a/servers/system/keyboard/init.c
+++ b/servers/system/keyboard/init.c
@@ -68,32 +68,19 @@ int main(void)
     }
 
     // Handle the IRQs.
-    if (system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
-    {
-        keyboard_irq_handler();
-    }
+    system_thread_create(keyboard_irq_handler, NULL);
 
-    if (has_mouse && system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
+    if (has_mouse)
     {
-        mouse_irq_handler();
+        system_thread_create(mouse_irq_handler, NULL);
     }
 
     // Handle the services.
-    if (system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
-    {
-        if (keyboard_main())
-        {
-            return 0;
-        }
-        else
-        {
-            return -1;
-        }
-    }
+    system_thread_create(keyboard_main, NULL);
 
-    if (has_mouse && system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
+    if (has_mouse)
     {
-        mouse_main();
+        system_thread_create(mouse_main, NULL);
     }
 
     system_call_process_parent_unblock();

--- a/servers/system/keyboard/init.c
+++ b/servers/system/keyboard/init.c
@@ -1,23 +1,8 @@
-/* $Id$ */
-/* Abstract: Keyboard initialisation code. */
-/* Author: Per Lundberg <per@halleluja.nu> */
+// Abstract: Keyboard initialisation code.
+// Author: Per Lundberg <per@halleluja.nu>
 
-/* Copyright 2000 chaos development. */
-
-/* This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License as
-   published by the Free Software Foundation; either version 2 of the
-   License, or (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful, but
-   WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-   USA. */
+// © Copyright 2000 chaos development
+// © Copyright 2015 chaos development
 
 #include "config.h"
 #include "common.h"
@@ -26,111 +11,92 @@
 #include "keyboard.h"
 #include "mouse.h"
 
-/* Initialise the server. */
-
-bool init (void)
+// Initialise the server.
+bool init(void)
 {
-  const char *message;
+    const char *message;
 
-  /* Initialise the memory library. */
-  
-  memory_init ();
+    memory_init();
+    system_process_name_set(PACKAGE_NAME);
 
-  /* Set our name. */
+    /* Initialise a connection to the log service. */
+    //  log_init (&log_structure, PACKAGE_NAME);
 
-  system_process_name_set (PACKAGE_NAME);
+    if (system_call_port_range_register(CONTROLLER_PORT_BASE, CONTROLLER_PORTS, "Keyboard controller") != STORM_RETURN_SUCCESS)
+    {
+        //    log_print (&log_structure, LOG_URGENCY_EMERGENCY,
+        //               "Could not allocate portrange 0x60 - 0x6F.");
+        return FALSE;
+    }
 
-  /* Initialise a connection to the log service. */
+    // Flush any pending input.
+    keyboard_clear_input();
 
-  //  log_init (&log_structure, PACKAGE_NAME);
+    message = keyboard_init();
+    if (message != NULL)
+    {
+        //log_print (&log_structure, LOG_URGENCY_ERROR, message);
+    }
 
-  /* Try to allocate the keyboard controller's ports. */
+    // Initialise a PS/2 mouse port, if found.
+    mouse_init();
 
-  if (system_call_port_range_register (CONTROLLER_PORT_BASE,
-                                       CONTROLLER_PORTS,
-                                       "Keyboard controller") !=
-      STORM_RETURN_SUCCESS)
-  {
-    //    log_print (&log_structure, LOG_URGENCY_EMERGENCY,
-    //               "Could not allocate portrange 0x60 - 0x6F.");
-    return FALSE;
-  }
-
-  /* Flush any pending input. */
-
-  keyboard_clear_input ();
-
-  message = keyboard_init ();
-  if (message != NULL)
-  {
-    //log_print (&log_structure, LOG_URGENCY_ERROR, message);
-  }
-
-  /* Initialise a PS/2 mouse port, if found. */
-
-  mouse_init ();
-
-  return TRUE;
+    return TRUE;
 }
 
-int main (void)
+int main(void)
 {
-  /* Set our name. */
+    system_process_name_set("keyboard");
+    system_thread_name_set("Initialising");
 
-  system_process_name_set ("keyboard");
-  system_thread_name_set ("Initialising");
+    // Detect whether a keyboard and/or mouse is present, and if so, put them into a usable state.
 
-  /* Detect whether a keyboard and/or mouse is present, and if so, put
-     them into a usable state. */
+    if (!init())
+    {
+        //    log_print (&log_structure, LOG_URGENCY_EMERGENCY,
+        //               "Failed initialisation.");
+        return 0;
+    }
 
-  if (!init ())
-  {
-    //    log_print (&log_structure, LOG_URGENCY_EMERGENCY,
-    //               "Failed initialisation.");
+    //  log_print (&log_structure, LOG_URGENCY_INFORMATIVE,
+    //             "Keyboard found at I/O 0x60-0x6F, IRQ 1.");
+
+    if (has_mouse)
+    {
+        //    log_print (&log_structure, LOG_URGENCY_INFORMATIVE,
+        //               "Mouse found at IRQ 12.");
+    }
+
+    // Handle the IRQs.
+    if (system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
+    {
+        keyboard_irq_handler();
+    }
+
+    if (has_mouse && system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
+    {
+        mouse_irq_handler();
+    }
+
+    // Handle the services.
+    if (system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
+    {
+        if (keyboard_main())
+        {
+            return 0;
+        }
+        else
+        {
+            return -1;
+        }
+    }
+
+    if (has_mouse && system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
+    {
+        mouse_main();
+    }
+
+    system_call_process_parent_unblock();
+
     return 0;
-  }
-
-  //  log_print (&log_structure, LOG_URGENCY_INFORMATIVE,
-  //             "Keyboard found at I/O 0x60-0x6F, IRQ 1.");
-
-  if (has_mouse)
-  {
-    //    log_print (&log_structure, LOG_URGENCY_INFORMATIVE,
-    //               "Mouse found at IRQ 12.");
-  }
-
-  /* Handle the IRQs. */
-
-  if (system_thread_create () == SYSTEM_RETURN_THREAD_NEW)
-  {
-    keyboard_irq_handler ();
-  }
-
-  if (has_mouse && system_thread_create () == SYSTEM_RETURN_THREAD_NEW)
-  {
-    mouse_irq_handler ();
-  }
-  
-  /* Handle the services. */
-
-  if (system_thread_create () == SYSTEM_RETURN_THREAD_NEW)
-  {
-    if (keyboard_main ())
-    {
-      return 0;
-    }
-    else
-    {
-      return -1;
-    }
-  }
-
-  if (has_mouse && system_thread_create () == SYSTEM_RETURN_THREAD_NEW)
-  {
-    mouse_main ();
-  }
-
-  system_call_process_parent_unblock ();
-
-  return 0;
 }

--- a/servers/system/keyboard/init.c
+++ b/servers/system/keyboard/init.c
@@ -1,6 +1,6 @@
 // Abstract: Keyboard initialisation code.
 // Author: Per Lundberg <per@halleluja.nu>
-
+//
 // © Copyright 2000 chaos development
 // © Copyright 2015 chaos development
 

--- a/servers/system/keyboard/keyboard.c
+++ b/servers/system/keyboard/keyboard.c
@@ -468,7 +468,7 @@ void keyboard_handle_event(u8 scancode)
 }
 
 // Handler for the keyboard IRQ.
-void keyboard_irq_handler(void)
+void keyboard_irq_handler(void *argument UNUSED)
 {
     system_thread_name_set("Keyboard IRQ handler");
 
@@ -627,7 +627,7 @@ static void handle_connection(ipc_structure_type *ipc_structure)
 }
 
 // Main function for the keyboard handling.
-bool keyboard_main(void)
+void keyboard_main(void *argument UNUSED)
 {
     console_structure_type console_structure;
 

--- a/servers/system/keyboard/keyboard.c
+++ b/servers/system/keyboard/keyboard.c
@@ -1,20 +1,18 @@
-/* $Id$ */
-/* Abstract: Keyboard server for chaos. */
-/* Authors: Per Lundberg <per@halleluja.nu>,
-            Henrik Hallin <hal@chaosdev.org> */
+// Abstract: Keyboard server for chaos.
+// Authors: Per Lundberg <per@halleluja.nu>,
+//          Henrik Hallin <hal@chaosdev.org>
+//
+// © Copyright 1999-2000 chaos development
+// © Copyright 2007 chaos development
+// © Copyright 2015 chaos development
 
-/* Copyright 1999-2000 chaos development. */
-/* Copyright 2007 chaos development. */
-
-/* Parts of this file was inspired by the (GPL:ed) Linux keyboard
-   support. */
+// Parts of this file was inspired by the Linux keyboard support. Should be rewritten, both to get rid of the GPL viral
+// effect but also since the code quality of some parts here are incredibly bad. Probably the parts we wrote
+// ourselves... ;)
 
 #include "config.h"
 
-/* FIXME: Set this to a dummy map, and let the boot-server set the
-   right key map. Or something. */
-/* A Swedish translation map, for now. */
-
+// FIXME: Set this to a dummy map, and let the boot-server set the right key map. Or something.
 #include "keyboard_maps/british.h"
 #include "keyboard_maps/swedish.h"
 #include "keyboard_maps/dvorak.h"
@@ -26,713 +24,626 @@
 #include "mouse.h"
 #include "scan_code.h"
 
-/* The keyboard maps convert keys to standard UTF-8 sequences. */
-
+// The keyboard maps convert keys to standard UTF-8 sequences.
 static const char **keyboard_map = swedish_keyboard_map;
 static const char **keyboard_map_shift = swedish_keyboard_map_shift;
 static const char **keyboard_map_altgr = swedish_keyboard_map_altgr;
 
-/* We need to create an array of 16 bytes, for storing the currently
-   pressed keys in. (128 scan codes / 8). */
-
+// We need to create an array of 16 bytes, for storing the currently pressed keys in. (128 scan codes / 8).
 static volatile u8 keyboard_pressed_keys[16];
 
-/* State of the *lock-keys. */
+// State of the *lock-keys.
 
 static volatile u8 keyboard_state_scroll = 0x0F;
 static volatile u8 keyboard_state_num = 0x0F;
 static volatile u8 keyboard_state_caps = 0x0F;
 
-/* The shift state. */
-
 static volatile unsigned int shift_state = 0;
 
 static volatile mailbox_id_type keyboard_target_mailbox_id = MAILBOX_ID_NONE;
 
-/* Is a keyboard connected? */
-
+// Is a keyboard connected?
 static bool keyboard_exists = TRUE;
 
-/* Used only by send_data - set by keyboard_interrupt. */
-
+// Used only by send_data - set by keyboard_interrupt.
 static volatile int reply_expected = 0;
 static volatile int acknowledge = 0;
 static volatile int resend = 0;
 
-/* Conversion table from keyboard scan codes to the standardised
-   'special key' codes, which are generic between all platforms. */
-
+// Conversion table from keyboard scan codes to the standardised 'special key' codes, which are generic between all platforms.
 static u8 special_key_conversion[] =
 {
-  [SCAN_CODE_ESCAPE] = IPC_KEYBOARD_SPECIAL_KEY_ESCAPE,
-  [SCAN_CODE_BACK_SPACE] = IPC_KEYBOARD_SPECIAL_KEY_BACK_SPACE,
-  [SCAN_CODE_TAB] = IPC_KEYBOARD_SPECIAL_KEY_TAB,
-  [SCAN_CODE_ENTER] = IPC_KEYBOARD_SPECIAL_KEY_ENTER,
-  [SCAN_CODE_CONTROL] = IPC_KEYBOARD_SPECIAL_KEY_CONTROL,
-  [SCAN_CODE_LEFT_SHIFT] = IPC_KEYBOARD_SPECIAL_KEY_LEFT_SHIFT,
-  [SCAN_CODE_RIGHT_SHIFT] = IPC_KEYBOARD_SPECIAL_KEY_RIGHT_SHIFT,
-  [SCAN_CODE_PRINT_SCREEN] = IPC_KEYBOARD_SPECIAL_KEY_PRINT_SCREEN,
-  [SCAN_CODE_ALT] = IPC_KEYBOARD_SPECIAL_KEY_ALT,
-  [SCAN_CODE_SPACE_BAR] = IPC_KEYBOARD_SPECIAL_KEY_SPACE_BAR,
-  [SCAN_CODE_CAPS_LOCK] = IPC_KEYBOARD_SPECIAL_KEY_CAPS_LOCK,
-  [SCAN_CODE_F1] = IPC_KEYBOARD_SPECIAL_KEY_F1,
-  [SCAN_CODE_F2] = IPC_KEYBOARD_SPECIAL_KEY_F2,
-  [SCAN_CODE_F3] = IPC_KEYBOARD_SPECIAL_KEY_F3,
-  [SCAN_CODE_F4] = IPC_KEYBOARD_SPECIAL_KEY_F4,
-  [SCAN_CODE_F5] = IPC_KEYBOARD_SPECIAL_KEY_F5,
-  [SCAN_CODE_F6] = IPC_KEYBOARD_SPECIAL_KEY_F6,
-  [SCAN_CODE_F7] = IPC_KEYBOARD_SPECIAL_KEY_F7,
-  [SCAN_CODE_F8] = IPC_KEYBOARD_SPECIAL_KEY_F8,
-  [SCAN_CODE_F9] = IPC_KEYBOARD_SPECIAL_KEY_F9,
-  [SCAN_CODE_F10] = IPC_KEYBOARD_SPECIAL_KEY_F10,
-  [SCAN_CODE_NUM_LOCK] = IPC_KEYBOARD_SPECIAL_KEY_NUM_LOCK,
-  [SCAN_CODE_SCROLL_LOCK] = IPC_KEYBOARD_SPECIAL_KEY_SCROLL_LOCK,
-  [SCAN_CODE_NUMERIC_7] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_7,
-  [SCAN_CODE_NUMERIC_8] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_8,
-  [SCAN_CODE_NUMERIC_9] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_9,
-  [SCAN_CODE_NUMERIC_MINUS] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_MINUS,
-  [SCAN_CODE_NUMERIC_4] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_4,
-  [SCAN_CODE_NUMERIC_5] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_5,
-  [SCAN_CODE_NUMERIC_6] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_6,
-  [SCAN_CODE_NUMERIC_PLUS] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_PLUS,
-  [SCAN_CODE_NUMERIC_1] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_1,
-  [SCAN_CODE_NUMERIC_2] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_2,
-  [SCAN_CODE_NUMERIC_3] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_3,
-  [SCAN_CODE_NUMERIC_0] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_0,
-  [SCAN_CODE_NUMERIC_DELETE] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_DELETE,
-  [SCAN_CODE_F11] = IPC_KEYBOARD_SPECIAL_KEY_F11,
-  [SCAN_CODE_F12] = IPC_KEYBOARD_SPECIAL_KEY_F12,
-  [SCAN_CODE_LEFT_WINDOWS] = IPC_KEYBOARD_SPECIAL_KEY_LEFT_WINDOWS,
-  [SCAN_CODE_RIGHT_WINDOWS] = IPC_KEYBOARD_SPECIAL_KEY_RIGHT_WINDOWS,
-  [SCAN_CODE_MENU] = IPC_KEYBOARD_SPECIAL_KEY_MENU,
+    [SCAN_CODE_ESCAPE] = IPC_KEYBOARD_SPECIAL_KEY_ESCAPE,
+    [SCAN_CODE_BACK_SPACE] = IPC_KEYBOARD_SPECIAL_KEY_BACK_SPACE,
+    [SCAN_CODE_TAB] = IPC_KEYBOARD_SPECIAL_KEY_TAB,
+    [SCAN_CODE_ENTER] = IPC_KEYBOARD_SPECIAL_KEY_ENTER,
+    [SCAN_CODE_CONTROL] = IPC_KEYBOARD_SPECIAL_KEY_CONTROL,
+    [SCAN_CODE_LEFT_SHIFT] = IPC_KEYBOARD_SPECIAL_KEY_LEFT_SHIFT,
+    [SCAN_CODE_RIGHT_SHIFT] = IPC_KEYBOARD_SPECIAL_KEY_RIGHT_SHIFT,
+    [SCAN_CODE_PRINT_SCREEN] = IPC_KEYBOARD_SPECIAL_KEY_PRINT_SCREEN,
+    [SCAN_CODE_ALT] = IPC_KEYBOARD_SPECIAL_KEY_ALT,
+    [SCAN_CODE_SPACE_BAR] = IPC_KEYBOARD_SPECIAL_KEY_SPACE_BAR,
+    [SCAN_CODE_CAPS_LOCK] = IPC_KEYBOARD_SPECIAL_KEY_CAPS_LOCK,
+    [SCAN_CODE_F1] = IPC_KEYBOARD_SPECIAL_KEY_F1,
+    [SCAN_CODE_F2] = IPC_KEYBOARD_SPECIAL_KEY_F2,
+    [SCAN_CODE_F3] = IPC_KEYBOARD_SPECIAL_KEY_F3,
+    [SCAN_CODE_F4] = IPC_KEYBOARD_SPECIAL_KEY_F4,
+    [SCAN_CODE_F5] = IPC_KEYBOARD_SPECIAL_KEY_F5,
+    [SCAN_CODE_F6] = IPC_KEYBOARD_SPECIAL_KEY_F6,
+    [SCAN_CODE_F7] = IPC_KEYBOARD_SPECIAL_KEY_F7,
+    [SCAN_CODE_F8] = IPC_KEYBOARD_SPECIAL_KEY_F8,
+    [SCAN_CODE_F9] = IPC_KEYBOARD_SPECIAL_KEY_F9,
+    [SCAN_CODE_F10] = IPC_KEYBOARD_SPECIAL_KEY_F10,
+    [SCAN_CODE_NUM_LOCK] = IPC_KEYBOARD_SPECIAL_KEY_NUM_LOCK,
+    [SCAN_CODE_SCROLL_LOCK] = IPC_KEYBOARD_SPECIAL_KEY_SCROLL_LOCK,
+    [SCAN_CODE_NUMERIC_7] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_7,
+    [SCAN_CODE_NUMERIC_8] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_8,
+    [SCAN_CODE_NUMERIC_9] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_9,
+    [SCAN_CODE_NUMERIC_MINUS] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_MINUS,
+    [SCAN_CODE_NUMERIC_4] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_4,
+    [SCAN_CODE_NUMERIC_5] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_5,
+    [SCAN_CODE_NUMERIC_6] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_6,
+    [SCAN_CODE_NUMERIC_PLUS] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_PLUS,
+    [SCAN_CODE_NUMERIC_1] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_1,
+    [SCAN_CODE_NUMERIC_2] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_2,
+    [SCAN_CODE_NUMERIC_3] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_3,
+    [SCAN_CODE_NUMERIC_0] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_0,
+    [SCAN_CODE_NUMERIC_DELETE] = IPC_KEYBOARD_SPECIAL_KEY_NUMERIC_DELETE,
+    [SCAN_CODE_F11] = IPC_KEYBOARD_SPECIAL_KEY_F11,
+    [SCAN_CODE_F12] = IPC_KEYBOARD_SPECIAL_KEY_F12,
+    [SCAN_CODE_LEFT_WINDOWS] = IPC_KEYBOARD_SPECIAL_KEY_LEFT_WINDOWS,
+    [SCAN_CODE_RIGHT_WINDOWS] = IPC_KEYBOARD_SPECIAL_KEY_RIGHT_WINDOWS,
+    [SCAN_CODE_MENU] = IPC_KEYBOARD_SPECIAL_KEY_MENU,
 
 #if FALSE
-  [SCAN_CODE_INSERT] = IPC_KEYBOARD_SPECIAL_KEY_INSERT,
-  [SCAN_CODE_HOME] = IPC_KEYBOARD_SPECIAL_KEY_HOME,
-  [SCAN_CODE_END] = IPC_KEYBOARD_SPECIAL_KEY_END,
+    [SCAN_CODE_INSERT] = IPC_KEYBOARD_SPECIAL_KEY_INSERT,
+    [SCAN_CODE_HOME] = IPC_KEYBOARD_SPECIAL_KEY_HOME,
+    [SCAN_CODE_END] = IPC_KEYBOARD_SPECIAL_KEY_END,
 #endif
 };
 
-/* Acknowledge the keyboard controller. */
-
-static int do_acknowledge (unsigned char scancode)
+// Acknowledge the keyboard controller.
+static int do_acknowledge(unsigned char scancode)
 {
-  if (reply_expected != 0) 
-  {
-    /* Unfortunately, we must recognise these codes only if we know
-       they are known to be valid (i.e., after sending a command),
-       because there are some brain-damaged keyboards (yes, FOCUS 9000
-       again) which have keys with such codes :( */
-
-    if (scancode == KEYBOARD_REPLY_ACK) 
+    if (reply_expected != 0)
     {
-      acknowledge = 1;
-      reply_expected = 0;
-      return 0;
+        // Unfortunately, we must recognise these codes only if we know they are known to be valid (i.e., after sending a
+        // command), because there are some brain-damaged keyboards (yes, FOCUS 9000 again) which have keys with such codes :(
+        if (scancode == KEYBOARD_REPLY_ACK)
+        {
+            acknowledge = 1;
+            reply_expected = 0;
+            return 0;
+        }
+        else if (scancode == KEYBOARD_REPLY_RESEND)
+        {
+            resend = 1;
+            reply_expected = 0;
+            return 0;
+        }
     }
-    else if (scancode == KEYBOARD_REPLY_RESEND) 
+    return 1;
+}
+
+// send_data sends a character to the keyboard and waits for an acknowledge, possibly retrying if asked to. Returns the
+// success status.
+static bool send_data(unsigned char data)
+{
+    int retries = 3;
+
+    do
     {
-      resend = 1;
-      reply_expected = 0;
-      return 0;
-    }
-  }
-  return 1;
-}
+        unsigned long timeout = KEYBOARD_TIMEOUT;
 
-/* send_data sends a character to the keyboard and waits for an
-   acknowledge, possibly retrying if asked to. Returns the success
-   status. */
+        // Set by interrupt routine on receipt of ACK.
+        acknowledge = 0;
+        resend = 0;
+        reply_expected = 1;
+        controller_write_output_word(data);
 
-static bool send_data (unsigned char data)
-{
-  int retries = 3;
-  
-  do 
-  {
-    unsigned long timeout = KEYBOARD_TIMEOUT;
-    
-    /* Set by interrupt routine on receipt of ACK. */
-
-    acknowledge = 0;
-    resend = 0;
-    reply_expected = 1;
-    controller_write_output_word (data);
-
-    while (TRUE)
-    {
-      while (TRUE)
-      {
-        u8 status = controller_read_status ();
-        u8 scancode;
-
-        /* Loop until there is data available. */
-        
-        if ((status & CONTROLLER_STATUS_OUTPUT_BUFFER_FULL) == 0)
+        while (TRUE)
         {
-          continue;
-        }  
-
-        /* Get it. */
-
-        scancode = controller_read_input ();
-        
-        /* Wait until there is a message available. */
-
-        if ((status & CONTROLLER_STATUS_MOUSE_OUTPUT_BUFFER_FULL) != 0)
-        {
-          continue;
-        }
-        else
-        {
-          do_acknowledge (scancode);
-          break;
-        }
-      }
-
-      if (acknowledge != 0)
-      {
-        return TRUE;
-      }
-
-      if (resend != 0)
-      {
-        break;
-      }
-
-      system_sleep (1);
-      timeout--;
-      
-      if (timeout == 0)
-      {
-        //log_print (&log_structure, LOG_URGENCY_ERROR,
-        //                   "Timeout - AT keyboard not present?");
-        return FALSE;
-      }
-    }
-  } while (retries-- > 0);
-  
-  //log_print (&log_structure, LOG_URGENCY_ERROR,
-  //             "Too many NACKs -- noisy keyboard cable?");
-  return FALSE;
-}
-
-/* Set the typematic repeat rate of the keyboard. */
-
-const char *keyboard_set_repeat_rate (void)
-{
-  /* Finally, set the typematic rate to maximum. */
-
-  controller_write_output_word (KEYBOARD_COMMAND_SET_RATE);
-  if (controller_wait_for_input () != KEYBOARD_REPLY_ACK)
-  {
-    return "Set rate: no ACK.";
-  }
-
-  controller_write_output_word (0x00);
-  if (controller_wait_for_input () != KEYBOARD_REPLY_ACK)
-  {
-    return "Set rate: no ACK.";
-  }
-  return NULL;
-}
-
-/* Update the keyboard LEDs. */
-/* FIXME: Defines!!! */
-
-void keyboard_update_leds (void)
-{
-  u8 output = 0;
-
-
-  if (keyboard_state_scroll == 0xF0)
-  {
-    output = 1;
-  }
-
-  if (keyboard_state_num == 0xF0)
-  {
-    output |= 2;
-  }
-
-  if (keyboard_state_caps == 0xF0)
-  {
-    output |= 4;
-  }
-
-  if (keyboard_exists && (!send_data (KEYBOARD_COMMAND_SET_LEDS) ||
-                          !send_data (output))) 
-  {
-    /* Re-enable keyboard if any errors. */
-
-    send_data (KEYBOARD_COMMAND_ENABLE);
-    keyboard_exists = FALSE;
-  }
-}
-
-/* Check if the given code is currently pressed. */
-
-static inline bool key_pressed (u8 scancode)
-{
-  if ((keyboard_pressed_keys[scancode / 8] & (1 << (scancode % 8))) != 0)
-  {
-    return TRUE;
-  }
-  else
-  {
-    return FALSE;
-  }
-}
-
-/* Translate the given key according to the current keyboard map. */
-
-static const char *translate_key (u8 scancode)
-{
-  if ((shift_state & KEYBOARD_LEFT_SHIFT) == KEYBOARD_LEFT_SHIFT ||
-      (shift_state & KEYBOARD_RIGHT_SHIFT) == KEYBOARD_RIGHT_SHIFT ||
-      keyboard_state_caps == 0xF0)
-  {
-    return keyboard_map_shift[scancode];
-  }
-  else if (key_pressed (SCAN_CODE_ALT))
-  {
-    return keyboard_map_altgr[scancode];
-  }
-  else
-  {
-    return keyboard_map[scancode];
-  }
-}
-
-/* Handle a keyboard event. This function is called from the interrupt
-   handler. */
-
-void keyboard_handle_event (u8 scancode)
-{
-  keyboard_exists = TRUE;
-
-  if (do_acknowledge (scancode))
-  {
-    const char *translated_key;
-    message_parameter_type message_parameter;
-    keyboard_packet_type keyboard_packet;
-    
-    //    char tmpstr[100];
- 
-    //    string_print (tmpstr, "ull: %u", scancode);
-    //    system_call_debug_print_simple (tmpstr);
-
-    memory_set_u8 ((u8 *) &keyboard_packet, 0, sizeof (keyboard_packet_type));
-
-    /* Special case -- this one is sent to us when the keyboard is
-       reset from an external device (like a keyboard/monitor
-       switch). It is also sent when right shift is released. What a
-       sick world this is... */
-
-    if (scancode == 170)
-    {
-      keyboard_update_leds ();
-      keyboard_set_repeat_rate ();
-    }
-
-    if ((scancode & 0x80) == 0) 
-    {
-      /* A key was pressed. */
-      
-      keyboard_pressed_keys[scancode / 8] |= (1 << (scancode % 8));
-      
-      /* Check if the pressed key is a lock key. */
-      
-      switch (scancode)
-      {
-        case SCAN_CODE_CAPS_LOCK:
-        {
-          keyboard_state_caps = ~keyboard_state_caps;
-          keyboard_update_leds ();
-          break;
-        }
-      
-        case SCAN_CODE_NUM_LOCK:
-        {
-          keyboard_state_num = ~keyboard_state_num;
-          keyboard_update_leds ();
-          break;
-        }
-      
-        case SCAN_CODE_SCROLL_LOCK:
-        {
-          keyboard_state_scroll = ~keyboard_state_scroll;
-          keyboard_update_leds ();
-          break;
-        }
-
-        /* Other key. */
-        
-        default:
-        {
-          /* Do we have a receiver registered? */
-
-          if (keyboard_target_mailbox_id != MAILBOX_ID_NONE)
-          {
-            /* Does this change the shift state? If so, set the flag
-               and notify our recipient. */
-
-            switch (scancode)
+            while (TRUE)
             {
-              case SCAN_CODE_LEFT_SHIFT:
-              {
-                shift_state |= KEYBOARD_LEFT_SHIFT;
-                break;
-              }
+                u8 status = controller_read_status();
+                u8 scancode;
 
-              case SCAN_CODE_RIGHT_SHIFT:
-              {
-                shift_state |= KEYBOARD_RIGHT_SHIFT;
-                break;
-              }
-
-              case SCAN_CODE_ALT:
-              {
-                shift_state |= KEYBOARD_RIGHT_ALT;
-                break;
-              }
-
-              case SCAN_CODE_CONTROL:
-              {
-                shift_state |= KEYBOARD_RIGHT_CONTROL;
-                break;
-              }
-              
-              default:
-              {
-                /* Seems to be a normal keypress. */
-                
-                keyboard_packet.key_pressed = TRUE;
-
-                /* Convert it to the chaos format. */
-
-                translated_key = translate_key (scancode);
-                
-                if (translated_key == NULL)
+                // Loop until there is data available.
+                if ((status & CONTROLLER_STATUS_OUTPUT_BUFFER_FULL) == 0)
                 {
-                  keyboard_packet.has_special_key = 1;
-                  keyboard_packet.special_key =
-                    special_key_conversion[scancode];
+                    continue;
+                }
+
+                // Get it.
+                scancode = controller_read_input();
+
+                // Wait until there is a message available.
+                if ((status & CONTROLLER_STATUS_MOUSE_OUTPUT_BUFFER_FULL) != 0)
+                {
+                    continue;
                 }
                 else
                 {
-                  keyboard_packet.has_character_code = 1;
-                  string_copy (keyboard_packet.character_code, translated_key);
+                    do_acknowledge(scancode);
+                    break;
                 }
-                break;
-              }
             }
-          }
-          
-          break;
+
+            if (acknowledge != 0)
+            {
+                return TRUE;
+            }
+
+            if (resend != 0)
+            {
+                break;
+            }
+
+            system_sleep(1);
+            timeout--;
+
+            if (timeout == 0)
+            {
+                //log_print (&log_structure, LOG_URGENCY_ERROR,
+                //                   "Timeout - AT keyboard not present?");
+                return FALSE;
+            }
         }
-      }
+    } while (retries-- > 0);
+
+    //log_print (&log_structure, LOG_URGENCY_ERROR,
+    //             "Too many NACKs -- noisy keyboard cable?");
+    return FALSE;
+}
+
+// Set the typematic repeat rate of the keyboard.
+const char *keyboard_set_repeat_rate(void)
+{
+    // Finally, set the typematic rate to maximum. */
+    controller_write_output_word(KEYBOARD_COMMAND_SET_RATE);
+    if (controller_wait_for_input() != KEYBOARD_REPLY_ACK)
+    {
+        return "Set rate: no ACK.";
+    }
+
+    controller_write_output_word(0x00);
+    if (controller_wait_for_input() != KEYBOARD_REPLY_ACK)
+    {
+        return "Set rate: no ACK.";
+    }
+    return NULL;
+}
+
+// Update the keyboard LEDs. */
+// FIXME: Defines!!! */
+void keyboard_update_leds(void)
+{
+    u8 output = 0;
+
+    if (keyboard_state_scroll == 0xF0)
+    {
+        output = 1;
+    }
+
+    if (keyboard_state_num == 0xF0)
+    {
+        output |= 2;
+    }
+
+    if (keyboard_state_caps == 0xF0)
+    {
+        output |= 4;
+    }
+
+    if (keyboard_exists && (!send_data(KEYBOARD_COMMAND_SET_LEDS) ||
+                            !send_data(output)))
+    {
+        // Re-enable keyboard if any errors.
+        send_data(KEYBOARD_COMMAND_ENABLE);
+        keyboard_exists = FALSE;
+    }
+}
+
+// Check if the given code is currently pressed.
+static inline bool key_pressed(u8 scancode)
+{
+    if ((keyboard_pressed_keys[scancode / 8] & (1 << (scancode % 8))) != 0)
+    {
+        return TRUE;
     }
     else
     {
-      /* A key was released. Start by masking away the highest bit and
-         update the keyboard_pressed_keys structure. */
+        return FALSE;
+    }
+}
 
-      scancode &= 0x7F;
-      keyboard_pressed_keys[scancode / 8] &= (~(1 << (scancode % 8)));
+// Translate the given key according to the current keyboard map.
+static const char *translate_key(u8 scancode)
+{
+    if ((shift_state & KEYBOARD_LEFT_SHIFT) == KEYBOARD_LEFT_SHIFT ||
+            (shift_state & KEYBOARD_RIGHT_SHIFT) == KEYBOARD_RIGHT_SHIFT ||
+            keyboard_state_caps == 0xF0)
+    {
+        return keyboard_map_shift[scancode];
+    }
+    else if (key_pressed(SCAN_CODE_ALT))
+    {
+        return keyboard_map_altgr[scancode];
+    }
+    else
+    {
+        return keyboard_map[scancode];
+    }
+}
 
-      /* If we have someone to send this to, do it. */
+// Handle a keyboard event. This function is called from the interrupt handler.
+void keyboard_handle_event(u8 scancode)
+{
+    keyboard_exists = TRUE;
 
-      if (keyboard_target_mailbox_id != MAILBOX_ID_NONE)
-      {
-        switch (scancode)
+    if (do_acknowledge(scancode))
+    {
+        const char *translated_key;
+        message_parameter_type message_parameter;
+        keyboard_packet_type keyboard_packet;
+
+        //    char tmpstr[100];
+
+        //    string_print (tmpstr, "ull: %u", scancode);
+        //    system_call_debug_print_simple (tmpstr);
+
+        memory_set_u8((u8 *) &keyboard_packet, 0, sizeof(keyboard_packet_type));
+
+        // Special case -- this one is sent to us when the keyboard is reset from an external device (like a
+        // keyboard/monitor switch). It is also sent when right shift is released. What a sick world this is...
+        if (scancode == 170)
         {
-          case SCAN_CODE_LEFT_SHIFT:
-          {
-            shift_state &= ~KEYBOARD_LEFT_SHIFT;
-            break;
-          }
-          
-          case SCAN_CODE_RIGHT_SHIFT:
-          {
-            shift_state &= ~KEYBOARD_RIGHT_SHIFT;
-            break;
-          }
-          
-          case SCAN_CODE_ALT:
-          {
-            shift_state &= ~KEYBOARD_RIGHT_ALT;
-            break;
-          }
-
-          case SCAN_CODE_CONTROL:
-          {
-            shift_state &= ~KEYBOARD_RIGHT_CONTROL;
-            break;
-          }
-      
-          /* Anything else will be E-lectric. */
-    
-          default:
-          {
-            keyboard_packet.key_pressed = FALSE;
-            translated_key = translate_key (scancode);
-            
-            /* If the key couldn't be translated, translate it in our own
-               way. */
-            
-            if (translated_key == NULL)
-            {
-              keyboard_packet.has_special_key = 1;
-              keyboard_packet.special_key = special_key_conversion[scancode];
-            }
-            else
-            {
-              keyboard_packet.has_character_code = 1;
-              string_copy (keyboard_packet.character_code, translated_key);
-            }
-          }
+            keyboard_update_leds();
+            keyboard_set_repeat_rate();
         }
-      }
+
+        if ((scancode & 0x80) == 0)
+        {
+            // A key was pressed. */
+            keyboard_pressed_keys[scancode / 8] |= (1 << (scancode % 8));
+
+            // Check if the pressed key is a lock key.
+            switch (scancode)
+            {
+                case SCAN_CODE_CAPS_LOCK:
+                {
+                    keyboard_state_caps = ~keyboard_state_caps;
+                    keyboard_update_leds();
+                    break;
+                }
+
+                case SCAN_CODE_NUM_LOCK:
+                {
+                    keyboard_state_num = ~keyboard_state_num;
+                    keyboard_update_leds();
+                    break;
+                }
+
+                case SCAN_CODE_SCROLL_LOCK:
+                {
+                    keyboard_state_scroll = ~keyboard_state_scroll;
+                    keyboard_update_leds();
+                    break;
+                }
+
+                // Other key.
+                default:
+                {
+                    // Do we have a receiver registered?
+                    if (keyboard_target_mailbox_id != MAILBOX_ID_NONE)
+                    {
+                        // Does this change the shift state? If so, set the flag and notify our recipient.
+                        switch (scancode)
+                        {
+                            case SCAN_CODE_LEFT_SHIFT:
+                            {
+                                shift_state |= KEYBOARD_LEFT_SHIFT;
+                                break;
+                            }
+
+                            case SCAN_CODE_RIGHT_SHIFT:
+                            {
+                                shift_state |= KEYBOARD_RIGHT_SHIFT;
+                                break;
+                            }
+
+                            case SCAN_CODE_ALT:
+                            {
+                                shift_state |= KEYBOARD_RIGHT_ALT;
+                                break;
+                            }
+
+                            case SCAN_CODE_CONTROL:
+                            {
+                                shift_state |= KEYBOARD_RIGHT_CONTROL;
+                                break;
+                            }
+
+                            default:
+                            {
+                                // Seems to be a normal keypress.
+                                keyboard_packet.key_pressed = TRUE;
+
+                                // Convert it to the chaos format.
+                                translated_key = translate_key(scancode);
+
+                                if (translated_key == NULL)
+                                {
+                                    keyboard_packet.has_special_key = 1;
+                                    keyboard_packet.special_key = special_key_conversion[scancode];
+                                }
+                                else
+                                {
+                                    keyboard_packet.has_character_code = 1;
+                                    string_copy(keyboard_packet.character_code, translated_key);
+                                }
+                                break;
+                            }
+                        }
+                    }
+
+                    break;
+                }
+            }
+        }
+        else
+        {
+            // A key was released. Start by masking away the highest bit and update the keyboard_pressed_keys structure.
+            scancode &= 0x7F;
+            keyboard_pressed_keys[scancode / 8] &= (~(1 << (scancode % 8)));
+
+            // If we have someone to send this to, do it.
+            if (keyboard_target_mailbox_id != MAILBOX_ID_NONE)
+            {
+                switch (scancode)
+                {
+                    case SCAN_CODE_LEFT_SHIFT:
+                    {
+                        shift_state &= ~KEYBOARD_LEFT_SHIFT;
+                        break;
+                    }
+
+                    case SCAN_CODE_RIGHT_SHIFT:
+                    {
+                        shift_state &= ~KEYBOARD_RIGHT_SHIFT;
+                        break;
+                    }
+
+                    case SCAN_CODE_ALT:
+                    {
+                        shift_state &= ~KEYBOARD_RIGHT_ALT;
+                        break;
+                    }
+
+                    case SCAN_CODE_CONTROL:
+                    {
+                        shift_state &= ~KEYBOARD_RIGHT_CONTROL;
+                        break;
+                    }
+
+                    // Anything else will be E-lectric.
+                    default:
+                    {
+                        keyboard_packet.key_pressed = FALSE;
+                        translated_key = translate_key(scancode);
+
+                        // If the key couldn't be translated, translate it in our own way.
+                        if (translated_key == NULL)
+                        {
+                            keyboard_packet.has_special_key = 1;
+                            keyboard_packet.special_key = special_key_conversion[scancode];
+                        }
+                        else
+                        {
+                            keyboard_packet.has_character_code = 1;
+                            string_copy(keyboard_packet.character_code, translated_key);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (keyboard_target_mailbox_id != MAILBOX_ID_NONE)
+        {
+            keyboard_packet.left_shift_down = ((shift_state & KEYBOARD_LEFT_SHIFT) == KEYBOARD_LEFT_SHIFT ? 1 : 0);
+            keyboard_packet.right_shift_down = ((shift_state & KEYBOARD_RIGHT_SHIFT) == KEYBOARD_RIGHT_SHIFT ? 1 : 0);
+            keyboard_packet.right_alt_down = ((shift_state & KEYBOARD_RIGHT_ALT) == KEYBOARD_RIGHT_ALT ? 1 : 0);
+            keyboard_packet.right_control_down = ((shift_state & KEYBOARD_RIGHT_CONTROL) == KEYBOARD_RIGHT_CONTROL ? 1 : 0);
+
+            // Send the key to the receiver.
+            message_parameter.protocol = IPC_PROTOCOL_CONSOLE;
+            message_parameter.message_class = IPC_CONSOLE_KEYBOARD_EVENT;
+            message_parameter.block = FALSE;
+            message_parameter.length = sizeof(keyboard_packet_type);
+            message_parameter.data = &keyboard_packet;
+
+            ipc_send(keyboard_target_mailbox_id, &message_parameter);
+        }
     }
-    
-    if (keyboard_target_mailbox_id != MAILBOX_ID_NONE)
-    {
-      keyboard_packet.left_shift_down = 
-        ((shift_state & KEYBOARD_LEFT_SHIFT) ==
-         KEYBOARD_LEFT_SHIFT ? 1 : 0);
-      keyboard_packet.right_shift_down = 
-        ((shift_state & KEYBOARD_RIGHT_SHIFT) ==
-         KEYBOARD_RIGHT_SHIFT ? 1 : 0);
-      keyboard_packet.right_alt_down = 
-        ((shift_state & KEYBOARD_RIGHT_ALT) ==
-         KEYBOARD_RIGHT_ALT ? 1 : 0);
-      keyboard_packet.right_control_down = 
-        ((shift_state & KEYBOARD_RIGHT_CONTROL) ==
-         KEYBOARD_RIGHT_CONTROL ? 1 : 0);
-      
-      /* Send the key to the receiver. */
-      
-      message_parameter.protocol = IPC_PROTOCOL_CONSOLE;
-      message_parameter.message_class = IPC_CONSOLE_KEYBOARD_EVENT;
-      message_parameter.block = FALSE;
-      message_parameter.length = sizeof (keyboard_packet_type);
-      message_parameter.data = &keyboard_packet;
-      
-      ipc_send (keyboard_target_mailbox_id, &message_parameter);
-    }
-  }
-}	
-
-/* Handler for the keyboard IRQ. */
-
-void keyboard_irq_handler (void)
-{
-  system_thread_name_set ("Keyboard IRQ handler");
-
-  /* Register our IRQ. Must be done by the IRQ handler thread, so we
-     do it here. */
-
-  if (system_call_irq_register (KEYBOARD_IRQ, "Keyboard controller")
-      != STORM_RETURN_SUCCESS)
-  {
-    //log_print (&log_structure, LOG_URGENCY_EMERGENCY,
-    //               "Could not allocate keyboard IRQ.");
-    return;
-  }
-
-  while (TRUE)
-  {
-    system_call_irq_wait (KEYBOARD_IRQ);
-    handle_event ();
-    system_call_irq_acknowledge (KEYBOARD_IRQ);
-  }
 }
 
-/* Initialise the keyboard. */
-
-const char *keyboard_init (void)
+// Handler for the keyboard IRQ.
+void keyboard_irq_handler(void)
 {
-  int status;
+    system_thread_name_set("Keyboard IRQ handler");
 
-  /* Test the keyboard interface. This seems to be the only way to get
-     it going.  If the test is successful a x55 is placed in the
-     input buffer. */
-
-  controller_write_command_word (CONTROLLER_COMMAND_SELF_TEST);
-  if (controller_wait_for_input () != 0x55)
-  {
-    return "Keyboard failed self test.";
-  }
-
-  /* Perform a keyboard interface test.  This causes the controller
-     to test the keyboard clock and data lines.  The results of the
-     test are placed in the input buffer. */
-
-  controller_write_command_word (CONTROLLER_COMMAND_KEYBOARD_TEST);
-  if (controller_wait_for_input () != 0x00)
-  {
-    return "Keyboard interface failed self test.";
-  }
-  
-  /* Enable the keyboard by allowing the keyboard clock to run. */
-
-  controller_write_command_word (CONTROLLER_COMMAND_KEYBOARD_ENABLE);
-
-  /* Reset keyboard. If the read times out then the assumption is that
-     no keyboard is plugged into the machine. This defaults the
-     keyboard to scan-code set 2.
-    
-     Set up to try again if the keyboard asks for RESEND. */
-
-  do 
-  {
-    controller_write_output_word (KEYBOARD_COMMAND_RESET);
-    status = controller_wait_for_input ();
-    if (status == KEYBOARD_REPLY_ACK)
+    // Register our IRQ. Must be done by the IRQ handler thread, so we do it here.
+    if (system_call_irq_register(KEYBOARD_IRQ, "Keyboard controller")
+            != STORM_RETURN_SUCCESS)
     {
-      break;
-    }
-
-    if (status != KEYBOARD_REPLY_RESEND)
-    {
-      return "Keyboard reset failed, no ACK.";
-    }
-  } while (TRUE);
-
-  if (controller_wait_for_input () != KEYBOARD_REPLY_POWER_ON_RESET)
-  {
-    return "Keyboard reset failed, bad reply.";
-  }
-
-  /* Set keyboard controller mode. During this, the keyboard should be
-     in the disabled state.
-     
-     Set up to try again if the keyboard asks for RESEND. */
-
-  do 
-  {
-    controller_write_output_word (KEYBOARD_COMMAND_DISABLE);
-    status = controller_wait_for_input ();
-    if (status == KEYBOARD_REPLY_ACK)
-    {  
-      break;
-    }
-
-    if (status != KEYBOARD_REPLY_RESEND)
-    {
-      return "Disable keyboard: no ACK.";
-    }
-  } while (TRUE);
-
-  controller_write_command_word (CONTROLLER_COMMAND_WRITE_MODE);
-  controller_write_output_word (CONTROLLER_MODE_KEYBOARD_INTERRUPT |
-                                CONTROLLER_MODE_SYS |
-                                CONTROLLER_MODE_DISABLE_MOUSE |
-                                CONTROLLER_MODE_KCC);
-  
-  /* IBM Power-PC portables need this to use scan-code set 1 -- Cort */
-  
-  controller_write_command_word (CONTROLLER_COMMAND_READ_MODE);
-  if ((controller_wait_for_input () & CONTROLLER_MODE_KCC) == 0) 
-  {
-    /* If the controller does not support conversion, Set the keyboard
-       to scan-code set 1.  */
-
-    controller_write_output_word (0xF0);
-    controller_wait_for_input ();
-    controller_write_output_word (0x01);
-    controller_wait_for_input ();
-  }
-
-  /* Enable the keyboard. */
-
-  controller_write_output_word (KEYBOARD_COMMAND_ENABLE);
-  if (controller_wait_for_input () != KEYBOARD_REPLY_ACK)
-  {
-    return "Enable keyboard: no ACK.";
-  }
-
-  /* Set the repeat rate. */
-
-  return keyboard_set_repeat_rate ();
-}
-
-
-/* Handle the connection to the console service. */
-
-static void handle_connection (ipc_structure_type *ipc_structure)
-{
-  bool done = FALSE;
-  message_parameter_type message_parameter;
-  u8 *data;
-  u8 **data_pointer = &data;
-  unsigned int data_size = 100;
-
-  memory_allocate ((void **) data_pointer, data_size);
-
-  keyboard_target_mailbox_id = ipc_structure->output_mailbox_id;
-  
-  /* Main loop. We just handle the packets we get in the way we
-     should. */
-
-  while (!done)
-  {
-    message_parameter.protocol = IPC_PROTOCOL_KEYBOARD;
-    message_parameter.message_class = IPC_CLASS_NONE;
-    message_parameter.length = data_size;
-    message_parameter.data = data;
-    message_parameter.block = TRUE;
-
-    if (ipc_receive (ipc_structure->input_mailbox_id,
-                     &message_parameter, &data_size) != IPC_RETURN_SUCCESS)
-    {
-      continue;
-    }
-
-    switch (message_parameter.message_class)
-    {
-      /* Unregister a receiver. */
-      
-      case IPC_KEYBOARD_UNREGISTER_TARGET:
-      {
-        keyboard_target_mailbox_id = MAILBOX_ID_NONE;
-
-        /* FIXME: Close the connection. */
-
+        //log_print (&log_structure, LOG_URGENCY_EMERGENCY,
+        //               "Could not allocate keyboard IRQ.");
         return;
-      }
     }
-  }
+
+    while (TRUE)
+    {
+        system_call_irq_wait(KEYBOARD_IRQ);
+        handle_event();
+        system_call_irq_acknowledge(KEYBOARD_IRQ);
+    }
 }
 
-/* Main function for the keyboard handling. */
-
-bool keyboard_main (void)
+// Initialise the keyboard.
+const char *keyboard_init(void)
 {
-  console_structure_type console_structure;
+    int status;
 
-  /* Update the keyboard LEDs. */
+    // Test the keyboard interface. This seems to be the only way to get it going.  If the test is successful a 0x55 is
+    // placed in the input buffer.
+    controller_write_command_word(CONTROLLER_COMMAND_SELF_TEST);
+    if (controller_wait_for_input() != 0x55)
+    {
+        return "Keyboard failed self test.";
+    }
 
-  keyboard_update_leds ();
+    // Perform a keyboard interface test.  This causes the controller to test the keyboard clock and data lines.  The
+    // results of the test are placed in the input buffer. */
 
-  /* No keys pressed at startup. */
+    controller_write_command_word(CONTROLLER_COMMAND_KEYBOARD_TEST);
+    if (controller_wait_for_input() != 0x00)
+    {
+        return "Keyboard interface failed self test.";
+    }
 
-  memory_set_u8 ((u8 * volatile) &keyboard_pressed_keys, 0,
-                 sizeof (keyboard_pressed_keys));
+    // Enable the keyboard by allowing the keyboard clock to run.
+    controller_write_command_word(CONTROLLER_COMMAND_KEYBOARD_ENABLE);
 
-  /* Establish a connection to the console service. */
+    // Reset keyboard. If the read times out then the assumption is that no keyboard is plugged into the machine. This
+    // defaults the keyboard to scan-code set 2.
+    //
+    // Set up to try again if the keyboard asks for RESEND.
+    do
+    {
+        controller_write_output_word(KEYBOARD_COMMAND_RESET);
+        status = controller_wait_for_input();
 
-  if (console_init (&console_structure, &empty_tag,
-                    IPC_CONSOLE_CONNECTION_CLASS_PROVIDER_KEYBOARD) !=
-      CONSOLE_RETURN_SUCCESS)
-  {
-    return FALSE;
-  }
+        if (status == KEYBOARD_REPLY_ACK)
+        {
+            break;
+        }
 
-  /* Main loop. */
+        if (status != KEYBOARD_REPLY_RESEND)
+        {
+            return "Keyboard reset failed, no ACK.";
+        }
+    } while (TRUE);
 
-  system_thread_name_set ("Handling connection");
-  handle_connection (&console_structure.ipc_structure);
-  return TRUE;
+    if (controller_wait_for_input() != KEYBOARD_REPLY_POWER_ON_RESET)
+    {
+        return "Keyboard reset failed, bad reply.";
+    }
+
+    // Set keyboard controller mode. During this, the keyboard should be in the disabled state.
+    //
+    // Set up to try again if the keyboard asks for RESEND.
+    do
+    {
+        controller_write_output_word(KEYBOARD_COMMAND_DISABLE);
+        status = controller_wait_for_input();
+        if (status == KEYBOARD_REPLY_ACK)
+        {
+            break;
+        }
+
+        if (status != KEYBOARD_REPLY_RESEND)
+        {
+            return "Disable keyboard: no ACK.";
+        }
+    } while (TRUE);
+
+    controller_write_command_word(CONTROLLER_COMMAND_WRITE_MODE);
+    controller_write_output_word(CONTROLLER_MODE_KEYBOARD_INTERRUPT |
+                                 CONTROLLER_MODE_SYS |
+                                 CONTROLLER_MODE_DISABLE_MOUSE |
+                                 CONTROLLER_MODE_KCC);
+
+    // IBM Power-PC portables need this to use scan-code set 1 -- Cort
+    controller_write_command_word(CONTROLLER_COMMAND_READ_MODE);
+    if ((controller_wait_for_input() & CONTROLLER_MODE_KCC) == 0)
+    {
+        // If the controller does not support conversion, Set the keyboard to scan-code set 1.
+        controller_write_output_word(0xF0);
+        controller_wait_for_input();
+        controller_write_output_word(0x01);
+        controller_wait_for_input();
+    }
+
+    // Enable the keyboard.
+    controller_write_output_word(KEYBOARD_COMMAND_ENABLE);
+    if (controller_wait_for_input() != KEYBOARD_REPLY_ACK)
+    {
+        return "Enable keyboard: no ACK.";
+    }
+
+    // Set the repeat rate.
+    return keyboard_set_repeat_rate();
+}
+
+// Handle the connection to the console service.
+static void handle_connection(ipc_structure_type *ipc_structure)
+{
+    bool done = FALSE;
+    message_parameter_type message_parameter;
+    u8 *data;
+    u8 **data_pointer = &data;
+    unsigned int data_size = 100;
+
+    memory_allocate((void **) data_pointer, data_size);
+
+    keyboard_target_mailbox_id = ipc_structure->output_mailbox_id;
+
+    // Main loop. We just handle the packets we get in the way we should.
+    while (!done)
+    {
+        message_parameter.protocol = IPC_PROTOCOL_KEYBOARD;
+        message_parameter.message_class = IPC_CLASS_NONE;
+        message_parameter.length = data_size;
+        message_parameter.data = data;
+        message_parameter.block = TRUE;
+
+        if (ipc_receive(ipc_structure->input_mailbox_id, &message_parameter, &data_size) != IPC_RETURN_SUCCESS)
+        {
+            continue;
+        }
+
+        switch (message_parameter.message_class)
+        {
+            // Unregister a receiver.
+            case IPC_KEYBOARD_UNREGISTER_TARGET:
+            {
+                keyboard_target_mailbox_id = MAILBOX_ID_NONE;
+
+                // FIXME: Close the connection.
+                return;
+            }
+        }
+    }
+}
+
+// Main function for the keyboard handling.
+bool keyboard_main(void)
+{
+    console_structure_type console_structure;
+
+    // Update the keyboard LEDs.
+    keyboard_update_leds();
+
+    // No keys pressed at startup.
+    memory_set_u8((u8 * volatile) &keyboard_pressed_keys, 0, sizeof(keyboard_pressed_keys));
+
+    // Establish a connection to the console service.
+    if (console_init(&console_structure, &empty_tag, IPC_CONSOLE_CONNECTION_CLASS_PROVIDER_KEYBOARD) != CONSOLE_RETURN_SUCCESS)
+    {
+        return;
+    }
+
+    // Main loop.
+    system_thread_name_set("Handling connection");
+    handle_connection(&console_structure.ipc_structure);
 }

--- a/servers/system/keyboard/keyboard.h
+++ b/servers/system/keyboard/keyboard.h
@@ -1,72 +1,47 @@
-/* $Id$ */
-/* Abstract: Header file for the keyboard server. */
+// Abstract: Header file for the keyboard server. Inspired by the Linux kernel.
 
-/* Copyright 1998-2000 chaos development. */
+// © Copyright 1998-2000 chaos development
+// © Copyright 2015 chaos development
 
-/* This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License as
-   published by the Free Software Foundation; either version 2 of the
-   License, or (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful, but
-   WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-   USA. */
-
-#ifndef __KEYBOARD_H__
-#define __KEYBOARD_H__
+#pragma once
 
 #include <system/system.h>
 
-/* Timeout in ms for keyboard command acknowledge. */
-
+// Timeout in ms for keyboard command acknowledge.
 #define KEYBOARD_TIMEOUT                        1000
 
-/* Timeout in ms for initializing the keyboard. */
-
+// Timeout in ms for initializing the keyboard.
 #define KEYBOARD_INIT_TIMEOUT                   1000
 
-/* Keyboard commands. */
-
+// Keyboard commands.
 #define KEYBOARD_COMMAND_SET_LEDS               0xED
 #define KEYBOARD_COMMAND_SET_RATE               0xF3
 #define KEYBOARD_COMMAND_ENABLE                 0xF4
 #define KEYBOARD_COMMAND_DISABLE                0xF5
 #define KEYBOARD_COMMAND_RESET                  0xFF
 
-/* Keyboard replies. */
-/* Power on reset. */
+// Keyboard replies.
+// Power on reset.
 
 #define KEYBOARD_REPLY_POWER_ON_RESET           0xAA
 
-/* Acknowledgement of previous command. */
-
+// Acknowledgement of previous command.
 #define KEYBOARD_REPLY_ACK                      0xFA
 
-/* Command NACK, send the command again. */
-
+// Command NACK, send the command again.
 #define KEYBOARD_REPLY_RESEND                   0xFE
 
-/* Hardware defines. */
-
+// Hardware defines.
 #define KEYBOARD_IRQ                            1
 
-/* Return values from keyboard_read_data (). */
-/* No data. */
-
+// Return values from keyboard_read_data().
+// No data.
 #define KEYBOARD_NO_DATA                        (-1)
 
-/* Parity or other error. */
-
+// Parity or other error.
 #define KEYBOARD_BAD_DATA                       (-2)
 
-/* Shift states. */
-
+// Shift states.
 #define KEYBOARD_LEFT_SHIFT                     (1 << 0)
 #define KEYBOARD_RIGHT_SHIFT                    (1 << 1)
 #define KEYBOARD_LEFT_ALT                       (1 << 2)
@@ -74,14 +49,11 @@
 #define KEYBOARD_LEFT_CONTROL                   (1 << 4)
 #define KEYBOARD_RIGHT_CONTROL                  (1 << 5)
 
-/* Function prototypes. */
-
+// Function prototypes. */
 extern void keyboard_clear_input(void);
-extern const char *keyboard_set_repeat_rate (void);
-extern void keyboard_handle_event (u8 scancode);
-extern const char *keyboard_init (void);
-extern void keyboard_update_leds (void);
-extern void keyboard_irq_handler (void);
-extern bool keyboard_main (void);
-
-#endif /* !__KEYBOARD_H__ */
+extern const char *keyboard_set_repeat_rate(void);
+extern void keyboard_handle_event(u8 scancode);
+extern const char *keyboard_init(void);
+extern void keyboard_update_leds(void);
+extern void keyboard_irq_handler(void *argument);
+extern bool keyboard_main(void);

--- a/servers/system/keyboard/keyboard.h
+++ b/servers/system/keyboard/keyboard.h
@@ -56,4 +56,4 @@ extern void keyboard_handle_event(u8 scancode);
 extern const char *keyboard_init(void);
 extern void keyboard_update_leds(void);
 extern void keyboard_irq_handler(void *argument);
-extern bool keyboard_main(void *argument);
+extern void keyboard_main(void *argument);

--- a/servers/system/keyboard/keyboard.h
+++ b/servers/system/keyboard/keyboard.h
@@ -56,4 +56,4 @@ extern void keyboard_handle_event(u8 scancode);
 extern const char *keyboard_init(void);
 extern void keyboard_update_leds(void);
 extern void keyboard_irq_handler(void *argument);
-extern bool keyboard_main(void);
+extern bool keyboard_main(void *argument);

--- a/servers/system/keyboard/keyboard.h
+++ b/servers/system/keyboard/keyboard.h
@@ -1,5 +1,5 @@
 // Abstract: Header file for the keyboard server. Inspired by the Linux kernel.
-
+//
 // © Copyright 1998-2000 chaos development
 // © Copyright 2015 chaos development
 

--- a/servers/system/keyboard/mouse.c
+++ b/servers/system/keyboard/mouse.c
@@ -1,360 +1,311 @@
-/* $Id$ */
-/* Abstract: PS/2 mouse code for the keyboard server. */
-/* Authors: Per Lundberg <per@halleluja.nu> 
-            Henrik Hallin <hal@chaosdev.org> */
-
-/* Copyright 2000 chaos development. */
-/* Copyright 2007 chaos development. */
+// Abstract: PS/2 mouse code for the keyboard server. */
+// Authors: Per Lundberg <per@halleluja.nu>
+//          Henrik Hallin <hal@chaosdev.org>
+//
+// © Copyright 2000 chaos development
+// © Copyright 2007 chaos development
+// © Copyright 2015 chaos development
 
 #include "common.h"
 #include "controller.h"
 #include "mouse.h"
 #include "config.h"
 
-/* Have we got a PS/2 mouse port? As of yet, we don't probe for the
-   actual existance of a *mouse*, just the port. This makes
-   hotswapping PS/2 mice easy. */
-
+// Have we got a PS/2 mouse port? As of yet, we don't probe for the actual existance of a *mouse*, just the port. This
+// makes hotswapping PS/2 mice easy.
 bool has_mouse = FALSE;
 
-/* This buffer holds the mouse scan codes. The PS/2 protocol sends
-   three characters for each event. */
-
+// This buffer holds the mouse scan codes. The PS/2 protocol sends three characters for each event.
 static u8 mouse_buffer[3];
 static int mouse_buffer_position = 0;
 
-/* The number of mouse replies expected. */
-
+// The number of mouse replies expected.
 static int mouse_replies_expected = 0;
 
-/* Hold the state of the mouse somewhere. */
-
+// Hold the state of the mouse somewhere.
 static mouse_type mouse;
 
-/* The mailbox ID of our receiver, if any. */
-
+// The mailbox ID of our receiver, if any.
 static volatile mailbox_id_type mouse_target_mailbox_id = MAILBOX_ID_NONE;
 
-/* Handler for the mouse IRQ. */
-
-void mouse_irq_handler (void)
+// Handler for the mouse IRQ.
+void mouse_irq_handler(void)
 {
-  system_thread_name_set ("Mouse IRQ handler");
+    system_thread_name_set("Mouse IRQ handler");
 
-  /* Register our IRQ. */
+    if (system_call_irq_register(MOUSE_IRQ, "PS/2 controller") != STORM_RETURN_SUCCESS)
+    {
+        //    log_print (&log_structure, LOG_URGENCY_EMERGENCY,
+        //         "Could not allocate IRQ.");
+        return;
+    }
 
-  if (system_call_irq_register (MOUSE_IRQ, "PS/2 controller")
-      != STORM_RETURN_SUCCESS)
-  {
-    //    log_print (&log_structure, LOG_URGENCY_EMERGENCY,
-    //         "Could not allocate IRQ.");
-    return;
-  }
-
-  while (TRUE)
-  {
-    system_call_irq_wait (MOUSE_IRQ);
-    handle_event ();
-    system_call_irq_acknowledge (MOUSE_IRQ);
-  }
+    while (TRUE)
+    {
+        system_call_irq_wait(MOUSE_IRQ);
+        handle_event();
+        system_call_irq_acknowledge(MOUSE_IRQ);
+    }
 }
 
-/* Handle a mouse event. */
-
-void mouse_handle_event (u8 scancode)
+// Handle a mouse event.
+void mouse_handle_event(u8 scancode)
 {
-
-  if (mouse_replies_expected > 0) 
-  {
-    if (scancode == MOUSE_ACK) 
+    if (mouse_replies_expected > 0)
     {
-      mouse_replies_expected--;
-      return;
+        if (scancode == MOUSE_ACK)
+        {
+            mouse_replies_expected--;
+            return;
+        }
+
+        mouse_replies_expected = 0;
     }
 
-    mouse_replies_expected = 0;
-  }
-  
-  /* Add this scancode to the mouse event queue. */
+    // Add this scancode to the mouse event queue.
+    mouse_buffer[mouse_buffer_position] = scancode;
+    mouse_buffer_position++;
 
-  mouse_buffer[mouse_buffer_position] = scancode;
-  mouse_buffer_position++;
-
-  /* If the buffer is full, parse this event. */
-
-  if (mouse_buffer_position == 3)
-  {
-    mouse_buffer_position = 0;
-
-    mouse.button_state = mouse_buffer[0] & MOUSE_BUTTON_MASK;
-    
-    /* Some PS/2 mice send reports with negative bit set in data[0]
-       and zero for movement.  I think this is a bug in the mouse, but
-       working around it only causes artifacts when the actual report
-       is -256; they'll be treated as zero. This should be rare if the
-       mouse sampling rate is set to a reasonable value; the default
-       of 100 Hz is plenty. (Stephen Tell) */
-    
-    /* Have the mouse moved horizontally? */
-
-    if (mouse_buffer[1] == 0)
+    // If the buffer is full, parse this event.
+    if (mouse_buffer_position == 3)
     {
-      mouse.delta_x = 0;
+        mouse_buffer_position = 0;
+
+        mouse.button_state = mouse_buffer[0] & MOUSE_BUTTON_MASK;
+
+        // Some PS/2 mice send reports with negative bit set in data[0] and zero for movement.  I think this is a bug in
+        // the mouse, but working around it only causes artifacts when the actual report is -256; they'll be treated as
+        // zero. This should be rare if the  mouse sampling rate is set to a reasonable value; the default of 100 Hz is
+        // plenty. (Stephen Tell)
+
+        // Has the mouse moved horizontally?
+        if (mouse_buffer[1] == 0)
+        {
+            mouse.delta_x = 0;
+        }
+        else
+        {
+            mouse.delta_x = (mouse_buffer[0] & MOUSE_NEGATIVE_X) != 0 ?
+                            mouse_buffer[1] - 256 :
+                            mouse_buffer[1];
+        }
+
+        // Or vertically?
+        if (mouse_buffer[2] == 0)
+        {
+            mouse.delta_y = 0;
+        }
+        else
+        {
+            mouse.delta_y = (mouse_buffer[0] & MOUSE_NEGATIVE_Y) != 0 ?
+                            mouse_buffer[2] - 256 :
+                            mouse_buffer[2];
+        }
+
+        mouse.x += mouse.delta_x;
+        mouse.y -= mouse.delta_y;
+
+        // Make sure we don't get Type'o Negative.
+        if (mouse.x < 0)
+        {
+            mouse.x = 0;
+        }
+
+        if (mouse.y < 0)
+        {
+            mouse.y = 0;
+        }
+
+        // Should we pass this event on to someone?
+        if (mouse_target_mailbox_id != MAILBOX_ID_NONE)
+        {
+            message_parameter_type message_parameter;
+            ipc_mouse_event_type ipc_mouse_event =
+            {
+                mouse.x, mouse.y, mouse.button_state
+            };
+
+            // Send the key to the receiver.
+            message_parameter.protocol = IPC_PROTOCOL_MOUSE;
+            message_parameter.message_class = IPC_MOUSE_EVENT;
+            message_parameter.block = FALSE;
+            message_parameter.length = sizeof(ipc_mouse_event_type);
+            message_parameter.data = &ipc_mouse_event;
+
+            ipc_send(mouse_target_mailbox_id, &message_parameter);
+        }
     }
-    else
-    {
-      mouse.delta_x = (mouse_buffer[0] & MOUSE_NEGATIVE_X) != 0 ?
-        mouse_buffer[1] - 256 :
-        mouse_buffer[1];
-    }
-
-    /* Or vertically? */
-    
-    if (mouse_buffer[2] == 0)
-    {
-      mouse.delta_y = 0;
-    }
-    else
-    {
-      mouse.delta_y = (mouse_buffer[0] & MOUSE_NEGATIVE_Y) != 0 ?
-        mouse_buffer[2] - 256 :
-        mouse_buffer[2];
-    }
-
-    mouse.x += mouse.delta_x;
-    mouse.y -= mouse.delta_y;
-
-    /* Make sure we don't get Type'o Negative. */
-
-    if (mouse.x < 0)
-    {
-      mouse.x = 0;
-    }
-
-    if (mouse.y < 0)
-    {
-      mouse.y = 0;
-    }
-
-    /* Should we pass this event on to someone? */
-
-    if (mouse_target_mailbox_id != MAILBOX_ID_NONE)
-    {
-      message_parameter_type message_parameter;
-      ipc_mouse_event_type ipc_mouse_event =
-      {
-        mouse.x, mouse.y, mouse.button_state
-      };
-
-      /* Send the key to the receiver. */
-      
-      message_parameter.protocol = IPC_PROTOCOL_MOUSE;
-      message_parameter.message_class = IPC_MOUSE_EVENT;
-      message_parameter.block = FALSE;
-      message_parameter.length = sizeof (ipc_mouse_event_type);
-      message_parameter.data = &ipc_mouse_event;
-      
-      ipc_send (mouse_target_mailbox_id, &message_parameter);
-    }
-  }
 }
 
-/* Write a PS/2 mouse command. */
-
-static void mouse_write_command (int command)
+// Write a PS/2 mouse command.
+static void mouse_write_command(int command)
 {
-  controller_wait ();
-  controller_write_command (CONTROLLER_COMMAND_WRITE_MODE);
-  controller_wait ();
-  controller_write_output (command);
+    controller_wait();
+    controller_write_command(CONTROLLER_COMMAND_WRITE_MODE);
+    controller_wait();
+    controller_write_output(command);
 }
 
-/* Send a byte to the PS/2 mouse & handle returned ACK. */
-
-static void mouse_write_ack (int value)
+// Send a byte to the PS/2 mouse & handle returned ACK.
+static void mouse_write_ack(int value)
 {
-  controller_wait ();
-  controller_write_command (CONTROLLER_COMMAND_WRITE_MOUSE);
-  controller_wait ();
-  controller_write_output (value);
+    controller_wait();
+    controller_write_command(CONTROLLER_COMMAND_WRITE_MOUSE);
+    controller_wait();
+    controller_write_output(value);
 
-  /* We expect an ACK in response. */
-
-  mouse_replies_expected++;
-  controller_wait ();
+    // We expect an ACK in response.
+    mouse_replies_expected++;
+    controller_wait();
 }
- 
-/* Check if this is a dual port controller. */
 
+// Check if this is a dual port controller.
 static bool detect_ps2_port(void)
 {
-  int loops;
-  bool return_value = FALSE;
-  
-  /* Put the value 0x5A in the output buffer using the "Write
-     Auxiliary Device Output Buffer" command (0xD3). Poll the Status
-     Register for a while to see if the value really turns up in the
-     Data Register. If the KEYBOARD_STATUS_MOUSE_OBF bit is also set to 1 in
-     the Status Register, we assume this controller has an Auxiliary
-     Port (a.k.a. Mouse Port). */
+    int loops;
+    bool return_value = FALSE;
 
-  controller_wait ();
-  controller_write_command (CONTROLLER_COMMAND_WRITE_MOUSE_OUTPUT_BUFFER);
-  
-  controller_wait ();
+    // Put the value 0x5A in the output buffer using the "Write Auxiliary Device Output Buffer" command (0xD3). Poll the
+    // Status Register for a while to see if the value really turns up in the Data Register. If the
+    // KEYBOARD_STATUS_MOUSE_OBF bit is also set to 1 in the Status Register, we assume this controller has an Auxiliary
+    // Port (a.k.a. Mouse Port). */
 
-  /* 0x5A is a random dummy value. */
+    controller_wait();
+    controller_write_command(CONTROLLER_COMMAND_WRITE_MOUSE_OUTPUT_BUFFER);
 
-  controller_write_output (0x5A);
-  
-  for (loops = 0; loops < 10;  loops++)
-  {
-    unsigned char status = controller_read_status();
-    
-    if ((status & CONTROLLER_STATUS_OUTPUT_BUFFER_FULL) != 0)
+    controller_wait();
+
+    // 0x5A is a random dummy value.
+    controller_write_output(0x5A);
+
+    for (loops = 0; loops < 10;  loops++)
     {
-      (void) controller_read_input ();
-      if ((status & CONTROLLER_STATUS_MOUSE_OUTPUT_BUFFER_FULL) != 0)
-      {
-        return_value = TRUE;
-      }
-      break;
+        unsigned char status = controller_read_status();
+
+        if ((status & CONTROLLER_STATUS_OUTPUT_BUFFER_FULL) != 0)
+        {
+            (void) controller_read_input();
+            if ((status & CONTROLLER_STATUS_MOUSE_OUTPUT_BUFFER_FULL) != 0)
+            {
+                return_value = TRUE;
+            }
+            break;
+        }
+
+        system_sleep(1);
     }
 
-    system_sleep (1);
-  }
-  
-  return return_value;
+    return return_value;
 }
 
-/* Initialise the PS/2 mouse support. */
-
-bool mouse_init (void)
+// Initialise the PS/2 mouse support.
+bool mouse_init(void)
 {
-  if (!detect_ps2_port ())
-  {
-    return FALSE;
-  }  
+    if (!detect_ps2_port())
+    {
+        return FALSE;
+    }
 
-  has_mouse = TRUE;
-  
- /* Enable the PS/2 mouse port. */
+    has_mouse = TRUE;
 
-  controller_write_command_word (CONTROLLER_COMMAND_MOUSE_ENABLE);
+    // Enable the PS/2 mouse port.
+    controller_write_command_word(CONTROLLER_COMMAND_MOUSE_ENABLE);
 
-  /* Samples/sec. */
+    // Samples/sec.
+    mouse_write_ack(MOUSE_SET_SAMPLE_RATE);
+    mouse_write_ack(MOUSE_SAMPLES_PER_SECOND);
 
-  mouse_write_ack (MOUSE_SET_SAMPLE_RATE);
-  mouse_write_ack (MOUSE_SAMPLES_PER_SECOND);
+    // 8 counts per mm.
+    mouse_write_ack(MOUSE_SET_RESOLUTION);
+    mouse_write_ack(3);
 
-  /* 8 counts per mm. */
+    // 2:1 scaling
+    mouse_write_ack(MOUSE_SET_SCALE21);
 
-  mouse_write_ack (MOUSE_SET_RESOLUTION);
-  mouse_write_ack (3);
+    // Enable the PS/2 device.
+    mouse_write_ack(MOUSE_ENABLE_DEVICE);
 
-  /* 2:1 scaling */
+    // Enable controller interrupts.
+    mouse_write_command(MOUSE_INTERRUPTS_ON);
 
-  mouse_write_ack (MOUSE_SET_SCALE21);
-
-  /* Enable the PS/2 device. */
-
-  mouse_write_ack (MOUSE_ENABLE_DEVICE);
-
-  /* Enable controller interrupts. */
-  
-  mouse_write_command (MOUSE_INTERRUPTS_ON);
-  
-  return TRUE;
+    return TRUE;
 }
 
-
-/* Handle a connection request. */
-
-static void handle_connection (mailbox_id_type reply_mailbox_id)
+// Handle a connection request.
+static void handle_connection(mailbox_id_type reply_mailbox_id)
 {
-  bool done = FALSE;
-  message_parameter_type message_parameter;
-  u8 *data;
-  u8 **data_pointer = &data;
-  ipc_structure_type ipc_structure;
-  unsigned int data_size = 100;
+    bool done = FALSE;
+    message_parameter_type message_parameter;
+    u8 *data;
+    u8 **data_pointer = &data;
+    ipc_structure_type ipc_structure;
+    unsigned int data_size = 100;
 
-  memory_allocate ((void **) data_pointer, data_size);
+    memory_allocate((void **) data_pointer, data_size);
 
-  /* Accept the connection. */ 
+    // Accept the connection.
+    ipc_structure.output_mailbox_id = reply_mailbox_id;
+    ipc_connection_establish(&ipc_structure);
 
-  ipc_structure.output_mailbox_id = reply_mailbox_id;
-  ipc_connection_establish (&ipc_structure);
-
-  /* Main loop. The connection is up, so we just handle the packets we
-     get in the way we should. */
-
-  while (!done)
-  {
-    message_parameter.protocol = IPC_PROTOCOL_MOUSE;
-    message_parameter.message_class = IPC_CLASS_NONE;
-    message_parameter.length = data_size;
-    message_parameter.data = data;
-    message_parameter.block = TRUE;
-
-    if (ipc_receive (ipc_structure.input_mailbox_id, &message_parameter,
-                     &data_size) != IPC_RETURN_SUCCESS)
+    // Main loop. The connection is up, so we just handle the packets we get in the way we should.
+    while (!done)
     {
-      continue;
-    }
+        message_parameter.protocol = IPC_PROTOCOL_MOUSE;
+        message_parameter.message_class = IPC_CLASS_NONE;
+        message_parameter.length = data_size;
+        message_parameter.data = data;
+        message_parameter.block = TRUE;
 
-    switch (message_parameter.message_class)
-    {
-      /* Someone wants to register as a receiver. */
+        if (ipc_receive(ipc_structure.input_mailbox_id, &message_parameter, &data_size) != IPC_RETURN_SUCCESS)
+        {
+            continue;
+        }
 
-      case IPC_MOUSE_REGISTER_TARGET:
-      {
-        mouse_target_mailbox_id = ipc_structure.output_mailbox_id;
-        break;
-      }
-      
-      /* Unregister a receiver. */
-      
-      case IPC_KEYBOARD_UNREGISTER_TARGET:
-      {
-        mouse_target_mailbox_id = MAILBOX_ID_NONE;
-        break;
-      }
+        switch (message_parameter.message_class)
+        {
+            // Someone wants to register as a receiver.
+            case IPC_MOUSE_REGISTER_TARGET:
+            {
+                mouse_target_mailbox_id = ipc_structure.output_mailbox_id;
+                break;
+            }
+
+            // Unregister a receiver.
+            case IPC_KEYBOARD_UNREGISTER_TARGET:
+            {
+                mouse_target_mailbox_id = MAILBOX_ID_NONE;
+                break;
+            }
+        }
     }
-  }
 }
 
-/* Main function for the mouse handling. */
-
-void mouse_main (void)
+// Main function for the mouse handling.
+void mouse_main(void)
 {
-  ipc_structure_type ipc_structure;
+    ipc_structure_type ipc_structure;
 
-  /* Create the service. */
-
-  if (ipc_service_create ("mouse", &ipc_structure, 
-                          &empty_tag) != IPC_RETURN_SUCCESS)
-  {
-    //    log_print (&log_structure, LOG_URGENCY_EMERGENCY,
-    //         "Couldn't create service.");
-    return;
-  }
-
-  /* Main loop. */
-
-  system_thread_name_set ("Service handler");
-  while (TRUE)
-  {
-    mailbox_id_type reply_mailbox_id;
-
-    ipc_service_connection_wait (&ipc_structure);
-    reply_mailbox_id = ipc_structure.output_mailbox_id;
-
-    if (system_thread_create () == SYSTEM_RETURN_THREAD_NEW)
+    // Create the service.
+    if (ipc_service_create("mouse", &ipc_structure, &empty_tag) != IPC_RETURN_SUCCESS)
     {
-      system_thread_name_set ("Handling connection");
-
-      handle_connection (reply_mailbox_id);
+        //    log_print (&log_structure, LOG_URGENCY_EMERGENCY,
+        //         "Couldn't create service.");
+        return;
     }
-  }
+
+    system_thread_name_set("Service handler");
+    while (TRUE)
+    {
+        mailbox_id_type reply_mailbox_id;
+
+        ipc_service_connection_wait(&ipc_structure);
+        reply_mailbox_id = ipc_structure.output_mailbox_id;
+
+        if (system_thread_create() == SYSTEM_RETURN_THREAD_NEW)
+        {
+            system_thread_name_set("Handling connection");
+
+            handle_connection(reply_mailbox_id);
+        }
+    }
 }

--- a/servers/system/keyboard/mouse.c
+++ b/servers/system/keyboard/mouse.c
@@ -232,11 +232,9 @@ bool mouse_init(void)
 }
 
 // Handle a connection request.
-static void handle_connection(void *argument)
+static void handle_connection(mailbox_id_type *reply_mailbox_id)
 {
     system_thread_name_set("Handling connection");
-
-    mailbox_id_type reply_mailbox_id = *(mailbox_id_type *) argument;
 
     bool done = FALSE;
     message_parameter_type message_parameter;
@@ -248,7 +246,7 @@ static void handle_connection(void *argument)
     memory_allocate((void **) data_pointer, data_size);
 
     // Accept the connection.
-    ipc_structure.output_mailbox_id = reply_mailbox_id;
+    ipc_structure.output_mailbox_id = *reply_mailbox_id;
     ipc_connection_establish(&ipc_structure);
 
     // Main loop. The connection is up, so we just handle the packets we get in the way we should.
@@ -305,6 +303,6 @@ void mouse_main(void *argument UNUSED)
         ipc_service_connection_wait(&ipc_structure);
         reply_mailbox_id = ipc_structure.output_mailbox_id;
 
-        system_thread_create(handle_connection, &reply_mailbox_id);
+        system_thread_create((thread_entry_point_type *) handle_connection, &reply_mailbox_id);
     }
 }

--- a/servers/system/keyboard/mouse.h
+++ b/servers/system/keyboard/mouse.h
@@ -1,75 +1,47 @@
-/* $Id$ */
-/* Abstract: Mouse commands. */
-/* Author: Per Lundberg <per@halleluja.nu> */
+// Abstract: Mouse commands. Probably inspired by the Linux kernel.
+// Author: Per Lundberg <per@halleluja.nu> */
 
-/* Copyright 2000 chaos development. */
+// © Copyright 2000 chaos development
+// © Copyright 2015 chaos development
 
-/* This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License as
-   published by the Free Software Foundation; either version 2 of the
-   License, or (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful, but
-   WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-   USA. */
-
-#ifndef __MOUSE_H__
-#define __MOUSE_H__
+#pragma once
 
 #include <system/system.h>
 
-/* Constants. */
-/* How many times per second the mouse reports updates. */
-
+// Constants.
+// How many times per second the mouse reports updates.
 #define MOUSE_SAMPLES_PER_SECOND        100
 
-/* Mouse commands. */
-/* Set resolution. */
-
+// Mouse commands.
+// Set resolution.
 #define MOUSE_SET_RESOLUTION            0xE8
 
-/* Set 1:1 scaling. */
-
+// Set 1:1 scaling.
 #define MOUSE_SET_SCALE11               0xE6
 
-/* Set 2:1 scaling. */
-
+// Set 2:1 scaling.
 #define MOUSE_SET_SCALE21               0xE7
 
-/* Get scaling factor. */
-
+// Get scaling factor.
 #define MOUSE_GET_SCALE                 0xE9
 
-/* Set stream mode. */
-
+// Set stream mode.
 #define MOUSE_SET_STREAM                0xEA
 
-/* Set sample rate (number of times the controller will poll the port
-   per second). */
-
+// Set sample rate (number of times the controller will poll the port per second).
 #define MOUSE_SET_SAMPLE_RATE           0xF3
 
-/* Enable mouse device. */
-
+// Enable mouse device.
 #define MOUSE_ENABLE_DEVICE             0xF4
 
-/* Disable mouse device. */
-
+// Disable mouse device.
 #define MOUSE_DISABLE_DEVICE            0xF5
 
-/* Reset aux device. */
-
+// Reset aux device.
 #define MOUSE_RESET                     0xFF
 
-/* Command byte ACK. */
-
-#define MOUSE_ACK			0xFA
+// Command byte ACK.
+#define MOUSE_ACK                       0xFA
 
 #define MOUSE_INTERRUPTS_OFF            (CONTROLLER_MODE_KCC | \
                                          CONTROLLER_MODE_DISABLE_MOUSE | \
@@ -81,46 +53,37 @@
                                          CONTROLLER_MODE_MOUSE_INTERRUPT | \
                                          CONTROLLER_MODE_KEYBOARD_INTERRUPT)
 
-/* Mouse movement flags. */
-
+// Mouse movement flags.
 #define MOUSE_NEGATIVE_Y                0x20
 #define MOUSE_NEGATIVE_X                0x10
 
-/* And buttons... */
-
+// And buttons...
 #define MOUSE_BUTTON_MASK               7
 #define MOUSE_BUTTON_RIGHT              1
 #define MOUSE_BUTTON_MIDDLE             4
 #define MOUSE_BUTTON_LEFT               2
 
-/* Some aux operations take long time. */
-
+// Some aux operations take long time.
 #define MAX_RETRIES                     60
 
-/* Hardware defines. */
-
+// Hardware defines.
 #define MOUSE_IRQ                       12
 
-/* Function prototypes. */
+// Function prototypes.
+extern void mouse_handle_event(u8 scancode);
+extern bool mouse_init(void);
+extern void mouse_irq_handler(void);
+extern void mouse_main(void);
 
-extern void mouse_handle_event (u8 scancode);
-extern bool mouse_init (void);
-extern void mouse_irq_handler (void);
-extern void mouse_main (void);
-
-/* Common variables. */
-
+// Common variables.
 extern bool has_mouse;
 
-/* Mouse structure. */
-
+// Mouse structure.
 typedef struct
 {
-  unsigned int button_state;
-  int delta_x;
-  int delta_y;
-  int x;
-  int y;
+    unsigned int button_state;
+    int delta_x;
+    int delta_y;
+    int x;
+    int y;
 } mouse_type;
-
-#endif /* !__MOUSE_H__ */

--- a/servers/system/keyboard/mouse.h
+++ b/servers/system/keyboard/mouse.h
@@ -72,8 +72,8 @@
 // Function prototypes.
 extern void mouse_handle_event(u8 scancode);
 extern bool mouse_init(void);
-extern void mouse_irq_handler(void);
-extern void mouse_main(void);
+extern void mouse_irq_handler(void *argument);
+extern void mouse_main(void *argument);
 
 // Common variables.
 extern bool has_mouse;

--- a/storm/generic/system_call.c
+++ b/storm/generic/system_call.c
@@ -37,9 +37,9 @@ return_type system_call_thread_name_set(char *name)
     return STORM_RETURN_SUCCESS;
 }
 
-return_type system_call_thread_create(void)
+return_type system_call_thread_create(void *(*start_routine) (void *), void *argument)
 {
-    return thread_create();
+    return thread_create(start_routine, argument);
 }
 
 return_type system_call_thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter)

--- a/storm/generic/system_call.c
+++ b/storm/generic/system_call.c
@@ -4,6 +4,7 @@
 // © Copyright 2000 chaos development
 // © Copyright 2007 chaos development
 // © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 // This file contains a wrapper for each system call function, which is responsible for locking the right mutex. Also, it
 // serves as an abstraction layer for the architecture dependent parts of the kernel.

--- a/storm/ia32/main.c
+++ b/storm/ia32/main.c
@@ -254,15 +254,6 @@ return_type kernel_main(int arguments, char *argument[])
                 break;
             }
 
-            // One or more of the sections was improperly page aligned.
-            case STORM_RETURN_UNALIGNED_SECTION:
-            {
-                debug_print("Error: %s has either the .text or .data section (or both) incorrectly aligned.\n",
-                            multiboot_module_info[index].name);
-                debug_run();
-                break;
-            }
-
             case RETURN_ELF_SECTION_MULTIPLE_INSTANCES:
             {
               debug_print("Error: There are multiple code or data sections in the ELF binary. This is not currently supported.\n");
@@ -271,7 +262,7 @@ return_type kernel_main(int arguments, char *argument[])
             }
 
             // The ELF was successfully executed.
-            case STORM_RETURN_SUCCESS:
+            case RETURN_SUCCESS:
             {
                 servers_started++;
                 debug_print("Started %s (process ID %u).\n",

--- a/storm/ia32/system_calls-auto.c
+++ b/storm/ia32/system_calls-auto.c
@@ -34,7 +34,7 @@ const system_call_type system_call[] =
   { SYSTEM_CALL_PROCESS_CREATE, wrapper_process_create, 1 },
   { SYSTEM_CALL_PROCESS_NAME_SET, wrapper_process_name_set, 1 },
   { SYSTEM_CALL_PROCESS_PARENT_UNBLOCK, wrapper_process_parent_unblock, 0 },
-  { SYSTEM_CALL_THREAD_CREATE, wrapper_thread_create, 0 },
+  { SYSTEM_CALL_THREAD_CREATE, wrapper_thread_create, 2 },
   { SYSTEM_CALL_THREAD_CONTROL, wrapper_thread_control, 3 },
   { SYSTEM_CALL_THREAD_NAME_SET, wrapper_thread_name_set, 1 },
   { SYSTEM_CALL_TIMER_READ, wrapper_timer_read, 1 },

--- a/storm/ia32/system_calls.rb
+++ b/storm/ia32/system_calls.rb
@@ -21,7 +21,7 @@ system_calls = Hash[
   'mailbox_receive',              2,
 
   'service_create',               3,
-  'service_destroy',		          1,
+  'service_destroy',              1,
   'service_get',                  3,
   'service_protocol_get',         2,
   'service_protocol_get_amount',  1,
@@ -36,7 +36,7 @@ system_calls = Hash[
   'irq_wait',                     1,
   'irq_acknowledge',              1,
 
-  'memory_allocate',		          3,
+  'memory_allocate',              3,
   'memory_deallocate',            1,
   'memory_reserve',               3,
   'memory_get_physical_address',  2,
@@ -48,9 +48,7 @@ system_calls = Hash[
   'process_name_set',             1,
   'process_parent_unblock',       0,
 
-  # 'cluster_create',		  0
-
-  'thread_create',                0,
+  'thread_create',                2,
   'thread_control',               3,
   'thread_name_set',              1,
 
@@ -84,11 +82,11 @@ void wrapper_#{system_call}(void)
       for parameter in 0..num_parameters - 1 do
         file.puts("\
       \"pushl 32 + 4 + #{num_parameters} * 4(%esp)\\n\"\n"
-        )                      
+        )
       end
 
       file.puts %Q[\
-      
+
       "call   system_call_#{system_call}\\n"\
       ]
 
@@ -130,7 +128,7 @@ def create_include_storm_system_calls_h(system_calls)
 #define SYSTEM_CALLS #{system_calls.keys.count}
 
 ")
-    
+
     file.puts "enum\n{\n  SYSTEM_CALL_#{system_calls.keys.first.upcase} = #{$gdt_start},\n"
 
     system_calls.keys[1...system_calls.keys.count].each do |system_call|

--- a/storm/ia32/thread.c
+++ b/storm/ia32/thread.c
@@ -217,7 +217,7 @@ thread_id_type thread_get_free_id(void)
 
 // FIXME: Some regions used by the kernel for temporary mappings need to be unique (or mutexed) to each thread under
 // a cluster. Discuss how this is best done! Right now, we lock everything, which is sub-optimal.
-return_type thread_create(void)
+return_type thread_create(void *(*start_routine) (void *), void *argument)
 {
     storm_tss_type *new_tss;
     page_directory_entry_page_table *new_page_directory = (page_directory_entry_page_table *) BASE_PROCESS_TEMPORARY;
@@ -257,7 +257,7 @@ return_type thread_create(void)
     mutex_kernel_signal(&tss_tree_mutex);
 
     // What has changed in the TSS is the ESP/ESP0 and the EIP. We must update those fields.
-    new_tss->eip = (u32) &&new_thread_entry;
+    new_tss->eip = (u32) start_routine;
     new_tss->cr3 = page_directory_physical_page * SIZE_PAGE;
 
     //  debug_print ("thread: %u\n", new_tss->thread_id);

--- a/storm/ia32/thread.c
+++ b/storm/ia32/thread.c
@@ -299,18 +299,13 @@ return_type thread_create(void)
 
     // FIXME: Map into all sister threads address spaces when creating a new page table for a thread.
 
-    // Start by creating a PL0 stack. Remember that the lowest page of the stack area is the PL0 stack.
     mutex_kernel_wait(&memory_mutex);
 
+    // Start by creating a PL0 stack. Remember that the lowest page of the stack area is the PL0 stack.
     // FIXME: Check return value.
     memory_physical_allocate(&stack_physical_page, 1, "Thread PL0 stack.");
-
-    memory_virtual_map(GET_PAGE_NUMBER(BASE_PROCESS_CREATE),
-                       stack_physical_page, 1, PAGE_KERNEL);
-
-    memory_copy((u8 *) BASE_PROCESS_CREATE, (u8 *) BASE_PROCESS_STACK,
-                SIZE_PAGE * 1);
-
+    memory_virtual_map(GET_PAGE_NUMBER(BASE_PROCESS_CREATE), stack_physical_page, 1, PAGE_KERNEL);
+    memory_copy((u8 *) BASE_PROCESS_CREATE, (u8 *) BASE_PROCESS_STACK, SIZE_PAGE * 1);
     memory_virtual_map_other(new_tss, GET_PAGE_NUMBER(BASE_PROCESS_STACK), stack_physical_page, 1, PAGE_KERNEL);
 
     // Phew... Finished setting up a PL0 stack. Lets take a deep breath and do the same for the PL3 stack, which is
@@ -318,18 +313,12 @@ return_type thread_create(void)
 
     // FIXME: Check return value.
     memory_physical_allocate(&stack_physical_page, current_tss->stack_pages, "Thread PL3 stack.");
-
-    memory_virtual_map(GET_PAGE_NUMBER(BASE_PROCESS_CREATE),
-                       stack_physical_page, current_tss->stack_pages,
-                       PAGE_KERNEL);
-
-    memory_copy((u8 *) BASE_PROCESS_CREATE,
-                (u8 *) ((MAX_PAGES - current_tss->stack_pages) * SIZE_PAGE),
+    memory_virtual_map(GET_PAGE_NUMBER(BASE_PROCESS_CREATE), stack_physical_page, current_tss->stack_pages, PAGE_KERNEL);
+    memory_copy((u8 *) BASE_PROCESS_CREATE, (u8 *) ((MAX_PAGES - current_tss->stack_pages) * SIZE_PAGE),
                 current_tss->stack_pages * SIZE_PAGE);
-
-    memory_virtual_map_other(new_tss, MAX_PAGES - current_tss->stack_pages,
-                             stack_physical_page, current_tss->stack_pages,
+    memory_virtual_map_other(new_tss, MAX_PAGES - current_tss->stack_pages, stack_physical_page, current_tss->stack_pages,
                              PAGE_WRITABLE | PAGE_NON_PRIVILEGED);
+
     mutex_kernel_signal(&memory_mutex);
 
     new_tss->ss = new_tss->ss0;

--- a/storm/ia32/thread.c
+++ b/storm/ia32/thread.c
@@ -1,7 +1,7 @@
 // Abstract: Thread routines. Part of the process system. Responsible for adding and removing threads under a cluster.
 // Authors: Henrik Hallin <hal@chaosdev.org>,
 //          Per Lundberg <per@halleluja.nu>
-
+//
 // © Copyright 1999-2000 chaos development
 // © Copyright 2013 chaos development
 // © Copyright 2015 chaos development

--- a/storm/ia32/trap.c
+++ b/storm/ia32/trap.c
@@ -2,12 +2,12 @@
 // Authors: Henrik Hallin <hal@chaosdev.org>
 //          Johan Thim <nospam@inter.net>
 //          Per Lundberg <per@halleluja.nu>
-
+//
 // © Copyright 1998-2000
 // © Copyright 2013 chaos development.
+// © Copyright 2015 chaos development.
 
 // Define this when debugging this module.
-
 #define DEBUG FALSE
 
 // Define this if you want to halt the system whenever an unhandled trap occurs. (Sometimes, the system will triple fault otherwise)

--- a/storm/ia32/wrapper.c
+++ b/storm/ia32/wrapper.c
@@ -6,7 +6,7 @@
 void wrapper_init(void)
 {
   asm("pushal\n"
-      
+
       "call   system_call_init\n"      
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
@@ -32,7 +32,7 @@ void wrapper_kernelfs_entry_read(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_kernelfs_entry_read\n"      
 
       // Restore the stack after the function call
@@ -65,7 +65,7 @@ void wrapper_mailbox_create(void)
       "pushl 32 + 4 + 5 * 4(%esp)\n"
       "pushl 32 + 4 + 5 * 4(%esp)\n"
       "pushl 32 + 4 + 5 * 4(%esp)\n"
-      
+
       "call   system_call_mailbox_create\n"      
 
       // Restore the stack after the function call
@@ -94,7 +94,7 @@ void wrapper_mailbox_destroy(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_mailbox_destroy\n"      
 
       // Restore the stack after the function call
@@ -123,7 +123,7 @@ void wrapper_mailbox_flush(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_mailbox_flush\n"      
 
       // Restore the stack after the function call
@@ -153,7 +153,7 @@ void wrapper_mailbox_send(void)
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 2 * 4(%esp)\n"
       "pushl 32 + 4 + 2 * 4(%esp)\n"
-      
+
       "call   system_call_mailbox_send\n"      
 
       // Restore the stack after the function call
@@ -183,7 +183,7 @@ void wrapper_mailbox_receive(void)
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 2 * 4(%esp)\n"
       "pushl 32 + 4 + 2 * 4(%esp)\n"
-      
+
       "call   system_call_mailbox_receive\n"      
 
       // Restore the stack after the function call
@@ -214,7 +214,7 @@ void wrapper_service_create(void)
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
-      
+
       "call   system_call_service_create\n"      
 
       // Restore the stack after the function call
@@ -243,7 +243,7 @@ void wrapper_service_destroy(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_service_destroy\n"      
 
       // Restore the stack after the function call
@@ -274,7 +274,7 @@ void wrapper_service_get(void)
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
-      
+
       "call   system_call_service_get\n"      
 
       // Restore the stack after the function call
@@ -304,7 +304,7 @@ void wrapper_service_protocol_get(void)
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 2 * 4(%esp)\n"
       "pushl 32 + 4 + 2 * 4(%esp)\n"
-      
+
       "call   system_call_service_protocol_get\n"      
 
       // Restore the stack after the function call
@@ -333,7 +333,7 @@ void wrapper_service_protocol_get_amount(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_service_protocol_get_amount\n"      
 
       // Restore the stack after the function call
@@ -366,7 +366,7 @@ void wrapper_dma_transfer(void)
       "pushl 32 + 4 + 5 * 4(%esp)\n"
       "pushl 32 + 4 + 5 * 4(%esp)\n"
       "pushl 32 + 4 + 5 * 4(%esp)\n"
-      
+
       "call   system_call_dma_transfer\n"      
 
       // Restore the stack after the function call
@@ -395,7 +395,7 @@ void wrapper_dma_transfer_cancel(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_dma_transfer_cancel\n"      
 
       // Restore the stack after the function call
@@ -425,7 +425,7 @@ void wrapper_dma_register(void)
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 2 * 4(%esp)\n"
       "pushl 32 + 4 + 2 * 4(%esp)\n"
-      
+
       "call   system_call_dma_register\n"      
 
       // Restore the stack after the function call
@@ -454,7 +454,7 @@ void wrapper_dma_unregister(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_dma_unregister\n"      
 
       // Restore the stack after the function call
@@ -484,7 +484,7 @@ void wrapper_irq_register(void)
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 2 * 4(%esp)\n"
       "pushl 32 + 4 + 2 * 4(%esp)\n"
-      
+
       "call   system_call_irq_register\n"      
 
       // Restore the stack after the function call
@@ -513,7 +513,7 @@ void wrapper_irq_unregister(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_irq_unregister\n"      
 
       // Restore the stack after the function call
@@ -542,7 +542,7 @@ void wrapper_irq_wait(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_irq_wait\n"      
 
       // Restore the stack after the function call
@@ -571,7 +571,7 @@ void wrapper_irq_acknowledge(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_irq_acknowledge\n"      
 
       // Restore the stack after the function call
@@ -602,7 +602,7 @@ void wrapper_memory_allocate(void)
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
-      
+
       "call   system_call_memory_allocate\n"      
 
       // Restore the stack after the function call
@@ -631,7 +631,7 @@ void wrapper_memory_deallocate(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_memory_deallocate\n"      
 
       // Restore the stack after the function call
@@ -662,7 +662,7 @@ void wrapper_memory_reserve(void)
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
-      
+
       "call   system_call_memory_reserve\n"      
 
       // Restore the stack after the function call
@@ -692,7 +692,7 @@ void wrapper_memory_get_physical_address(void)
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 2 * 4(%esp)\n"
       "pushl 32 + 4 + 2 * 4(%esp)\n"
-      
+
       "call   system_call_memory_get_physical_address\n"      
 
       // Restore the stack after the function call
@@ -723,7 +723,7 @@ void wrapper_port_range_register(void)
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
-      
+
       "call   system_call_port_range_register\n"      
 
       // Restore the stack after the function call
@@ -752,7 +752,7 @@ void wrapper_port_range_unregister(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_port_range_unregister\n"      
 
       // Restore the stack after the function call
@@ -781,7 +781,7 @@ void wrapper_process_create(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_process_create\n"      
 
       // Restore the stack after the function call
@@ -810,7 +810,7 @@ void wrapper_process_name_set(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_process_name_set\n"      
 
       // Restore the stack after the function call
@@ -835,7 +835,7 @@ void wrapper_process_name_set(void)
 void wrapper_process_parent_unblock(void)
 {
   asm("pushal\n"
-      
+
       "call   system_call_process_parent_unblock\n"      
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
@@ -857,8 +857,16 @@ void wrapper_process_parent_unblock(void)
 void wrapper_thread_create(void)
 {
   asm("pushal\n"
-      
+
+      // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
+      // so the "next parameter to push" is always in the same memory location. :)
+      "pushl 32 + 4 + 2 * 4(%esp)\n"
+      "pushl 32 + 4 + 2 * 4(%esp)\n"
+
       "call   system_call_thread_create\n"      
+
+      // Restore the stack after the function call
+      "addl   $4 * 2, %esp\n"      
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -873,7 +881,7 @@ void wrapper_thread_create(void)
 
       // Adjust the stack for the fact that EAX isn't being popped.
       "addl   $4, %esp\n"
-      "lret   $4 * 0\n");
+      "lret   $4 * 2\n");
 }
 
 void wrapper_thread_control(void)
@@ -885,7 +893,7 @@ void wrapper_thread_control(void)
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
       "pushl 32 + 4 + 3 * 4(%esp)\n"
-      
+
       "call   system_call_thread_control\n"      
 
       // Restore the stack after the function call
@@ -914,7 +922,7 @@ void wrapper_thread_name_set(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_thread_name_set\n"      
 
       // Restore the stack after the function call
@@ -943,7 +951,7 @@ void wrapper_timer_read(void)
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
       "pushl 32 + 4 + 1 * 4(%esp)\n"
-      
+
       "call   system_call_timer_read\n"      
 
       // Restore the stack after the function call
@@ -968,7 +976,7 @@ void wrapper_timer_read(void)
 void wrapper_dispatch_next(void)
 {
   asm("pushal\n"
-      
+
       "call   system_call_dispatch_next\n"      
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).

--- a/storm/include/storm/generic/return_values.h
+++ b/storm/include/storm/generic/return_values.h
@@ -2,15 +2,15 @@
 
 // Authors: Per Lundberg <per@halleluja.nu>
 //          Henrik Hallin <hal@chaosdev.org>
-// © Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 #include <storm/return_values.h>
 
 // Internal return values
 // FIXME: Look over this and see that all is good.
-// FIXME: Check if we can use a C++11 typed enum instead. Might be hard if we want C code to be able to use the header, which we
-// definitely want. :)
 enum
 {
     // Function returned successfully.

--- a/storm/include/storm/generic/system_call.h
+++ b/storm/include/storm/generic/system_call.h
@@ -1,7 +1,9 @@
 // Abstract: System call functions.
 // Author: Per Lundberg <per@halleluja.nu>
-
-// Copyright 2000, 2013 chaos development.
+//
+// © Copyright 2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/storm/include/storm/generic/system_call.h
+++ b/storm/include/storm/generic/system_call.h
@@ -48,6 +48,6 @@ extern return_type system_call_service_get(const char *protocol_name, service_pa
 extern return_type system_call_service_protocol_get_amount(unsigned int *number_of_protocols);
 extern return_type system_call_service_protocol_get(unsigned int *maximum_protocols, service_protocol_type *protocol_info);
 extern return_type system_call_thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter);
-extern return_type system_call_thread_create(void);
+extern return_type system_call_thread_create(void *(*start_routine) (void *), void *argument);
 extern return_type system_call_thread_name_set(char *name);
 extern return_type system_call_timer_read(time_type *timer);

--- a/storm/include/storm/generic/system_call.h
+++ b/storm/include/storm/generic/system_call.h
@@ -13,88 +13,41 @@
 #include <storm/generic/tag.h>
 #include <storm/generic/types.h>
 
-extern return_type system_call_dispatch_next (void);
-extern return_type system_call_thread_name_set (char *name);
-extern return_type system_call_thread_create (void);
-
-extern return_type system_call_thread_control 
-  (thread_id_type thread_id, unsigned int class, unsigned int parameter);
-
-extern return_type system_call_timer_read (time_type *timer);
-extern return_type system_call_process_name_set (char *name);
-extern return_type system_call_process_parent_unblock (void);
-
-extern return_type system_call_memory_reserve
-  (address_type start, unsigned int size, void **virtual_address);
-
-extern return_type system_call_port_range_register
-  (unsigned int start, unsigned int ports, char *description);
-
-extern return_type system_call_port_range_unregister (unsigned int start);
-
-extern return_type system_call_memory_allocate 
-  (void **address, u32 pages, bool cacheable);
-
-extern return_type system_call_memory_deallocate (void **address);
-
-extern return_type system_call_irq_wait (unsigned int irq_number);
-extern return_type system_call_irq_acknowledge (unsigned int irq_number);
-
-extern return_type system_call_irq_register
-  (unsigned int irq_number, char *description);
-
-extern return_type system_call_process_create
-  (process_create_type *process_data);
-
-extern return_type system_call_init (void);
-
-extern return_type system_call_memory_get_physical_address 
-  (void *virtual_address, void **physical_address);
-
-extern return_type system_call_dma_register
-  (unsigned int channel, void **dma_buffer);
-
-extern return_type system_call_dma_unregister (unsigned int channel);
-
-extern return_type system_call_dma_transfer 
-  (unsigned int channel, unsigned int buffer_size, unsigned int operation,
-   unsigned int transfer_mode, unsigned int autoinit);
-
-extern return_type system_call_dma_transfer_cancel (unsigned int channel);
-
-extern return_type system_call_kernelfs_entry_read
-  (kernelfs_generic_type *kernelfs_generic);
-
-return_type system_call_mailbox_create
-  (mailbox_id_type *mailbox_id, unsigned int size,
-   process_id_type user_process_id, cluster_id_type user_cluster_id,
-   thread_id_type user_thread_id);
-
-extern return_type system_call_mailbox_destroy
-  (mailbox_id_type mailbox_id);
-
-extern return_type system_call_mailbox_flush (mailbox_id_type mailbox_id);
-
-extern return_type system_call_mailbox_send
-  (mailbox_id_type mailbox_id, message_parameter_type *message_parameter);
-
-extern return_type system_call_mailbox_receive
-  (mailbox_id_type mailbox_id, message_parameter_type *message_parameter);
-
-extern return_type system_call_service_create
-  (const char *protocol_name,  mailbox_id_type *mailbox_id,
-   tag_type *identification);
-
-extern return_type system_call_service_destroy (mailbox_id_type mailbox_id);
-
-extern return_type system_call_service_get 
-  (const char *protocol_name, service_parameter_type *service_parameter,
-   tag_type *identification_mask);
-
-extern return_type system_call_service_protocol_get_amount 
-  (unsigned int *number_of_protocols);
-
-extern return_type system_call_service_protocol_get
-  (unsigned int *maximum_protocols, service_protocol_type *protocol_info);
-
-extern return_type system_call_irq_unregister (unsigned int irq_number);
+extern return_type system_call_dispatch_next(void);
+extern return_type system_call_thread_name_set(char *name);
+extern return_type system_call_thread_create(void);
+extern return_type system_call_thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter);
+extern return_type system_call_timer_read(time_type *timer);
+extern return_type system_call_process_name_set(char *name);
+extern return_type system_call_process_parent_unblock(void);
+extern return_type system_call_memory_reserve(address_type start, unsigned int size, void **virtual_address);
+extern return_type system_call_port_range_register(unsigned int start, unsigned int ports, char *description);
+extern return_type system_call_port_range_unregister(unsigned int start);
+extern return_type system_call_memory_allocate(void **address, u32 pages, bool cacheable);
+extern return_type system_call_memory_deallocate(void **address);
+extern return_type system_call_irq_wait(unsigned int irq_number);
+extern return_type system_call_irq_acknowledge(unsigned int irq_number);
+extern return_type system_call_irq_register(unsigned int irq_number, char *description);
+extern return_type system_call_process_create(process_create_type *process_data);
+extern return_type system_call_init(void);
+extern return_type system_call_memory_get_physical_address(void *virtual_address, void **physical_address);
+extern return_type system_call_dma_register(unsigned int channel, void **dma_buffer);
+extern return_type system_call_dma_unregister(unsigned int channel);
+extern return_type system_call_dma_transfer(unsigned int channel, unsigned int buffer_size, unsigned int operation,
+    unsigned int transfer_mode, unsigned int autoinit);
+extern return_type system_call_dma_transfer_cancel(unsigned int channel);
+extern return_type system_call_kernelfs_entry_read(kernelfs_generic_type *kernelfs_generic);
+return_type system_call_mailbox_create(mailbox_id_type *mailbox_id, unsigned int size, process_id_type user_process_id,
+    cluster_id_type user_cluster_id, thread_id_type user_thread_id);
+extern return_type system_call_mailbox_destroy(mailbox_id_type mailbox_id);
+extern return_type system_call_mailbox_flush(mailbox_id_type mailbox_id);
+extern return_type system_call_mailbox_send(mailbox_id_type mailbox_id, message_parameter_type *message_parameter);
+extern return_type system_call_mailbox_receive(mailbox_id_type mailbox_id, message_parameter_type *message_parameter);
+extern return_type system_call_service_create(const char *protocol_name,  mailbox_id_type *mailbox_id,
+    tag_type *identification);
+extern return_type system_call_service_destroy(mailbox_id_type mailbox_id);
+extern return_type system_call_service_get(const char *protocol_name, service_parameter_type *service_parameter,
+    tag_type *identification_mask);
+extern return_type system_call_service_protocol_get_amount(unsigned int *number_of_protocols);
+extern return_type system_call_service_protocol_get(unsigned int *maximum_protocols, service_protocol_type *protocol_info);
+extern return_type system_call_irq_unregister(unsigned int irq_number);

--- a/storm/include/storm/generic/system_call.h
+++ b/storm/include/storm/generic/system_call.h
@@ -14,28 +14,16 @@
 #include <storm/generic/types.h>
 
 extern return_type system_call_dispatch_next(void);
-extern return_type system_call_thread_name_set(char *name);
-extern return_type system_call_thread_create(void);
-extern return_type system_call_thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter);
-extern return_type system_call_timer_read(time_type *timer);
-extern return_type system_call_process_name_set(char *name);
-extern return_type system_call_process_parent_unblock(void);
-extern return_type system_call_memory_reserve(address_type start, unsigned int size, void **virtual_address);
-extern return_type system_call_port_range_register(unsigned int start, unsigned int ports, char *description);
-extern return_type system_call_port_range_unregister(unsigned int start);
-extern return_type system_call_memory_allocate(void **address, u32 pages, bool cacheable);
-extern return_type system_call_memory_deallocate(void **address);
-extern return_type system_call_irq_wait(unsigned int irq_number);
-extern return_type system_call_irq_acknowledge(unsigned int irq_number);
-extern return_type system_call_irq_register(unsigned int irq_number, char *description);
-extern return_type system_call_process_create(process_create_type *process_data);
-extern return_type system_call_init(void);
-extern return_type system_call_memory_get_physical_address(void *virtual_address, void **physical_address);
 extern return_type system_call_dma_register(unsigned int channel, void **dma_buffer);
-extern return_type system_call_dma_unregister(unsigned int channel);
 extern return_type system_call_dma_transfer(unsigned int channel, unsigned int buffer_size, unsigned int operation,
     unsigned int transfer_mode, unsigned int autoinit);
 extern return_type system_call_dma_transfer_cancel(unsigned int channel);
+extern return_type system_call_dma_unregister(unsigned int channel);
+extern return_type system_call_init(void);
+extern return_type system_call_irq_acknowledge(unsigned int irq_number);
+extern return_type system_call_irq_register(unsigned int irq_number, char *description);
+extern return_type system_call_irq_unregister(unsigned int irq_number);
+extern return_type system_call_irq_wait(unsigned int irq_number);
 extern return_type system_call_kernelfs_entry_read(kernelfs_generic_type *kernelfs_generic);
 return_type system_call_mailbox_create(mailbox_id_type *mailbox_id, unsigned int size, process_id_type user_process_id,
     cluster_id_type user_cluster_id, thread_id_type user_thread_id);
@@ -43,6 +31,15 @@ extern return_type system_call_mailbox_destroy(mailbox_id_type mailbox_id);
 extern return_type system_call_mailbox_flush(mailbox_id_type mailbox_id);
 extern return_type system_call_mailbox_send(mailbox_id_type mailbox_id, message_parameter_type *message_parameter);
 extern return_type system_call_mailbox_receive(mailbox_id_type mailbox_id, message_parameter_type *message_parameter);
+extern return_type system_call_memory_allocate(void **address, u32 pages, bool cacheable);
+extern return_type system_call_memory_deallocate(void **address);
+extern return_type system_call_memory_get_physical_address(void *virtual_address, void **physical_address);
+extern return_type system_call_memory_reserve(address_type start, unsigned int size, void **virtual_address);
+extern return_type system_call_port_range_register(unsigned int start, unsigned int ports, char *description);
+extern return_type system_call_port_range_unregister(unsigned int start);
+extern return_type system_call_process_create(process_create_type *process_data);
+extern return_type system_call_process_name_set(char *name);
+extern return_type system_call_process_parent_unblock(void);
 extern return_type system_call_service_create(const char *protocol_name,  mailbox_id_type *mailbox_id,
     tag_type *identification);
 extern return_type system_call_service_destroy(mailbox_id_type mailbox_id);
@@ -50,4 +47,7 @@ extern return_type system_call_service_get(const char *protocol_name, service_pa
     tag_type *identification_mask);
 extern return_type system_call_service_protocol_get_amount(unsigned int *number_of_protocols);
 extern return_type system_call_service_protocol_get(unsigned int *maximum_protocols, service_protocol_type *protocol_info);
-extern return_type system_call_irq_unregister(unsigned int irq_number);
+extern return_type system_call_thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter);
+extern return_type system_call_thread_create(void);
+extern return_type system_call_thread_name_set(char *name);
+extern return_type system_call_timer_read(time_type *timer);

--- a/storm/include/storm/generic/thread.h
+++ b/storm/include/storm/generic/thread.h
@@ -2,7 +2,9 @@
 // Authors: Henrik Hallin <hal@chaosdev.org>
 //          Per Lundberg <per@halleluja.nu>
 
-// Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/storm/include/storm/generic/thread.h
+++ b/storm/include/storm/generic/thread.h
@@ -21,28 +21,18 @@ extern tss_list_type *tss_list;
 extern tss_list_type *idle_tss_node;
 
 // Function prototypes.
-extern void thread_init (void);
-extern thread_id_type thread_get_free_id (void);
-extern return_type thread_control (thread_id_type thread_id,
-                                   unsigned int class,
-                                   unsigned int parameter);
-extern return_type thread_create (void);
-extern storm_tss_type *thread_get_tss (thread_id_type thread_id);
-extern tss_list_type *thread_link (storm_tss_type *tss);
-extern void thread_unlink (thread_id_type thread_id);
-extern tss_list_type *thread_link_list (tss_list_type **list,
-                                        storm_tss_type *tss);
-extern void thread_unlink_list (tss_list_type **list,
-                                thread_id_type thread_id);
-extern void thread_block_kernel_mutex (storm_tss_type *tss,
-                                       mutex_kernel_type *mutex_kernel);
-extern return_type thread_unblock_kernel_mutex (mutex_kernel_type
-                                                *mutex_kernel);
-
-extern void thread_block_mailbox_send (storm_tss_type *tss,
-                                       mailbox_id_type mailbox_id);
-extern void thread_block_mailbox_receive (storm_tss_type *tss,
-                                          mailbox_id_type mailbox_id);
-
-extern void thread_unblock_mailbox_send (mailbox_id_type mailbox_id);
-extern void thread_unblock_mailbox_receive (mailbox_id_type mailbox_id);
+extern void thread_init(void);
+extern thread_id_type thread_get_free_id(void);
+extern return_type thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter);
+extern return_type thread_create(void *(*start_routine)(void *), void *argument);
+extern storm_tss_type *thread_get_tss(thread_id_type thread_id);
+extern tss_list_type *thread_link(storm_tss_type *tss);
+extern void thread_unlink(thread_id_type thread_id);
+extern tss_list_type *thread_link_list(tss_list_type **list, storm_tss_type *tss);
+extern void thread_unlink_list(tss_list_type **list, thread_id_type thread_id);
+extern void thread_block_kernel_mutex(storm_tss_type *tss, mutex_kernel_type *mutex_kernel);
+extern return_type thread_unblock_kernel_mutex(mutex_kernel_type *mutex_kernel);
+extern void thread_block_mailbox_send(storm_tss_type *tss, mailbox_id_type mailbox_id);
+extern void thread_block_mailbox_receive(storm_tss_type *tss, mailbox_id_type mailbox_id);
+extern void thread_unblock_mailbox_send(mailbox_id_type mailbox_id);
+extern void thread_unblock_mailbox_receive(mailbox_id_type mailbox_id);

--- a/storm/include/storm/generic/thread.h
+++ b/storm/include/storm/generic/thread.h
@@ -1,7 +1,7 @@
 // Abstract: Thread functions.
 // Authors: Henrik Hallin <hal@chaosdev.org>
 //          Per Lundberg <per@halleluja.nu>
-
+//
 // © Copyright 1999-2000 chaos development
 // © Copyright 2013 chaos development
 // © Copyright 2015 chaos development

--- a/storm/include/storm/ia32/defines.h
+++ b/storm/include/storm/ia32/defines.h
@@ -3,7 +3,9 @@
 //          Henrik Hallin <hal@chaosdev.org>
 //          Anders Öhrt <doa@chaosdev.org>
 //
-// © Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/storm/include/storm/ia32/thread.h
+++ b/storm/include/storm/ia32/thread.h
@@ -1,12 +1,13 @@
 // Abstract: IA32-specific thread stuff.
 // Author: Per Lundberg <per@halleluja.nu>
 //
-// © Copyright 2000, 2013 chaos development.
+// © Copyright 2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 
 #include <storm/ia32/flags.h>
 
 // Default flags for new processes are IF, PF, AF. See the Intel documentation for more information about this.
-#define THREAD_NEW_EFLAGS (FLAG_INTERRUPT_ENABLE | FLAG_ADJUST | \
-                           FLAG_PARITY | FLAG_SET)
+#define THREAD_NEW_EFLAGS (FLAG_INTERRUPT_ENABLE | FLAG_ADJUST | FLAG_PARITY | FLAG_SET)

--- a/storm/include/storm/ia32/tss.h
+++ b/storm/include/storm/ia32/tss.h
@@ -124,9 +124,6 @@ typedef struct
     // The current size of the I/O map.
     unsigned int iomap_size;
 
-    // Is this the new Era of Personal Computing? Or is it just Linux and Windows - the dynamic duo?
-    bool new_thread;
-
     // Process capabilities.
     capability_type capability;
 

--- a/storm/include/storm/return_values.h
+++ b/storm/include/storm/return_values.h
@@ -30,12 +30,6 @@ enum
     // A limit has been overrun.
     STORM_RETURN_LIMIT_OVERRUN,
 
-    // The current thread is the new thread. (Returned by system_call_thread_create)
-    STORM_RETURN_THREAD_NEW,
-
-    // The current thread is the old thread. (Returned by system_call_thread_create)
-    STORM_RETURN_THREAD_OLD,
-
     // The DMA channel specified does not exist.
     STORM_RETURN_INVALID_DMA_CHANNEL,
 

--- a/storm/include/storm/return_values.h
+++ b/storm/include/storm/return_values.h
@@ -3,7 +3,9 @@
 //          Henrik Hallin <hal@chaosdev.org>
 //          Anders Ohrt <doa@chaosdev.org>
 //
-// © Copyright chaos development 1999-2000, 2013.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/storm/include/storm/storm.h
+++ b/storm/include/storm/storm.h
@@ -1,11 +1,11 @@
-/* Abstract: storm external header file. */
-/* Authors: Per Lundberg <per@halleluja.nu>
-            Henrik Hallin <hal@chaosdev.org> */           
+// Abstract: storm external header file.
+// Authors: Per Lundberg <per@halleluja.nu>
+//          Henrik Hallin <hal@chaosdev.org>
+//
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
 
-/* Copyright 1999-2000, 2013 chaos development. */
-
-#ifndef __STORM_STORM_H__
-#define __STORM_STORM_H__
+#pragma once
 
 #include <storm/types.h>
 #include <storm/defines.h>
@@ -20,5 +20,3 @@
 #include <storm/service.h>
 #include <storm/state.h>
 #include <storm/system_calls.h>
-
-#endif /* !__STORM_STORM_H__ */

--- a/storm/include/storm/types.h
+++ b/storm/include/storm/types.h
@@ -2,7 +2,9 @@
 // Authors: Per Lundberg <per@halleluja.nu>
 //          Henrik Hallin <hal@chaosdev.org>
 //
-// © Copyright 1998-2000, 2013 chaos development.
+// © Copyright 1998-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/storm/include/storm/types.h
+++ b/storm/include/storm/types.h
@@ -47,3 +47,4 @@ typedef unsigned int mailbox_id_type;
 typedef unsigned int mutex_id_type;
 typedef volatile int spinlock_type;
 typedef u32 limit_type;
+typedef void (thread_entry_point_type)(void *);


### PR DESCRIPTION
This is here now to fix #21. The way we used to do things simply don't cut it with more recent versions of `gcc`. Hence, I changed `thread_create` to take two parameters instead:

1. The name of the method that should be called as entry point for the new thread.
1. An argument that will be passed to that method. (Can be NULL in cases where you don't need it)

Coincidentally, this is very similar to how `pthread_create` already does it. :smile: 

The servers have also been fixed to work now with this approach; at least the `console` and the `vga` servers seem to be operational. Hence, merging.