### PR TITLE
Support larger servers than a few megabytes (don't hardwire physical AVL tree location)

### DIFF
--- a/storm/generic/avl.c
+++ b/storm/generic/avl.c
@@ -21,7 +21,7 @@
 
 // Given a new node, this function sets all properties for the node.
 void avl_node_reset(avl_node_type *node, unsigned int start, unsigned int busy_length, unsigned int free_length,
-                    avl_node_type *parent)
+                    avl_node_type *parent, const char *description)
 {
     node->start = start;
     node->busy_length = busy_length;
@@ -32,6 +32,7 @@ void avl_node_reset(avl_node_type *node, unsigned int start, unsigned int busy_l
     node->balance = 0;
     node->largest_free_less = 0;
     node->largest_free_more = 0;
+    node->description = description;
 }
 
 // Find a free node in the entry bitmap. This function is also responsible for growing the tree when needed.

--- a/storm/ia32/memory_global.c
+++ b/storm/ia32/memory_global.c
@@ -79,7 +79,7 @@ void memory_global_init(void)
 
     // Initialise the tree, starting with an empty entry.
     avl_node_reset(global_avl_header->root, GET_PAGE_NUMBER(BASE_GLOBAL_HEAP),
-                   0, SIZE_IN_PAGES(SIZE_GLOBAL_HEAP), NULL);
+                   0, SIZE_IN_PAGES(SIZE_GLOBAL_HEAP), NULL, "Unallocated global memory");
 
     // And mark that entry as used in the bitmap.
     global_avl_header->bitmap[0] = 1;
@@ -88,7 +88,7 @@ void memory_global_init(void)
     global_slab_heap = (slab_heap_type *) (memory_global_allocate_page(1) * SIZE_PAGE);
 
     // FIXME: Check return value.
-    memory_physical_allocate(&physical_page, 1, "Global SLAB heap.");
+    memory_physical_allocate(&physical_page, 1, "Global SLAB heap physical page.");
 
     memory_virtual_map(GET_PAGE_NUMBER(global_slab_heap), physical_page, 1, PAGE_KERNEL);
     slab_heap_init(global_slab_heap);
@@ -139,7 +139,7 @@ static u32 memory_global_allocate_page(u32 length)
                 insert_node = avl_node_allocate(global_avl_header);
 
                 avl_node_reset(insert_node, node->start + node->busy_length,
-                               length, node->free_length - length, NULL);
+                               length, node->free_length - length, NULL, "Global memory");
 
                 node->free_length = 0;
                 avl_update_tree_largest_free(node->parent);

--- a/storm/ia32/memory_physical.c
+++ b/storm/ia32/memory_physical.c
@@ -75,53 +75,45 @@ void memory_physical_init(void)
     memory_set_u8((u8 *) page_avl_header->bitmap, 0, physical_pages / 8);
 
     // Initialise the tree. All memory is free.
-    avl_node_reset(page_avl_header->root, 0, 0, physical_pages, NULL);
+    avl_node_reset(page_avl_header->root, 0, 0, physical_pages, NULL, "Unallocated physical memory");
 
     // And mark that entry as used in the bitmap.
     page_avl_header->bitmap[0] = 1;
 
     // Now, let's do it like they do on the discovery channel. Mark the reserved memory as reserved.
-    memory_physical_reserve(GET_PAGE_NUMBER(BASE_GDT), SIZE_IN_PAGES(SIZE_GDT_IDT));
-    memory_physical_reserve(GET_PAGE_NUMBER(BASE_KERNEL_TSS), SIZE_IN_PAGES(SIZE_KERNEL_TSS));
-    memory_physical_reserve(GET_PAGE_NUMBER(BASE_KERNEL_STACK), SIZE_IN_PAGES(SIZE_KERNEL_STACK));
-    memory_physical_reserve(GET_PAGE_NUMBER(BASE_MODULE_NAME), SIZE_IN_PAGES(SIZE_MODULE_NAME));
+    memory_physical_reserve(GET_PAGE_NUMBER(BASE_GDT), SIZE_IN_PAGES(SIZE_GDT_IDT), "IDT");
+    memory_physical_reserve(GET_PAGE_NUMBER(BASE_KERNEL_TSS), SIZE_IN_PAGES(SIZE_KERNEL_TSS), "Kernel TSS");
+    memory_physical_reserve(GET_PAGE_NUMBER(BASE_KERNEL_STACK), SIZE_IN_PAGES(SIZE_KERNEL_STACK), "Kernel stack");
+    memory_physical_reserve(GET_PAGE_NUMBER(BASE_MODULE_NAME), SIZE_IN_PAGES(SIZE_MODULE_NAME), "Module names");
 
     // Reserve the memory for the kernel.
-    memory_physical_reserve(GET_PAGE_NUMBER(BASE_KERNEL), SIZE_IN_PAGES((u32) &_end - BASE_KERNEL));
+    memory_physical_reserve(GET_PAGE_NUMBER(BASE_KERNEL), SIZE_IN_PAGES((u32) &_end - BASE_KERNEL), "Kernel code and data");
 
     // If we have more than 16 megs of RAM, we need to allocate DMA buffers to avoid lots of trouble later.
     // FIXME: Should be configurable via command line switch too.
-    DEBUG_MESSAGE(DEBUG, "Reserving memory for DMA...");
-
     // FIXME: For now, we have to do this unconditionally.
     // if (physical_pages * SIZE_PAGE > 16 * MB)
     {
-        memory_physical_reserve(GET_PAGE_NUMBER(BASE_DMA), SIZE_IN_PAGES(SIZE_DMA));
+        memory_physical_reserve(GET_PAGE_NUMBER(BASE_DMA), SIZE_IN_PAGES(SIZE_DMA), "DMA");
     }
 
     // The memory between 640k and 1024k are 'reserved' for various ISA plug in cards and other junk. Nevertheless, if
     // we mess with it, it may mess with us, so we'd better not.
-    DEBUG_MESSAGE(DEBUG, "Reserving high memory...");
-
-    memory_physical_reserve(GET_PAGE_NUMBER(BASE_UPPER), SIZE_IN_PAGES(SIZE_UPPER));
+    memory_physical_reserve(GET_PAGE_NUMBER(BASE_UPPER), SIZE_IN_PAGES(SIZE_UPPER), "High memory");
 
     // Reserve the memory used by the AVL system.
-    DEBUG_MESSAGE(DEBUG, "Reserving physical memory AVL-data...");
-
-    memory_physical_reserve(GET_PAGE_NUMBER((u32) page_avl_header), page_avl_pages);
+    memory_physical_reserve(GET_PAGE_NUMBER((u32) page_avl_header), page_avl_pages, "Physical memory AVL data");
 
     // And of course the server images too.
-    DEBUG_MESSAGE(DEBUG, "Reserving memory for servers...");
-
     for (counter = 0; counter < multiboot_info.number_of_modules; counter++)
     {
         memory_physical_reserve(GET_PAGE_NUMBER(multiboot_module_info[counter].start),
-            SIZE_IN_PAGES(multiboot_module_info[counter].end - multiboot_module_info[counter].start));
+            SIZE_IN_PAGES(multiboot_module_info[counter].end - multiboot_module_info[counter].start), "Server binaries");
     }
 }
 
 // Reserve a region, so it won't get allocated later.
-return_type memory_physical_reserve(unsigned int start, unsigned int length)
+return_type memory_physical_reserve(unsigned int start, unsigned int length, const char *description)
 {
     avl_node_type *node = page_avl_header->root;
     avl_node_type *insert_node;
@@ -151,8 +143,8 @@ return_type memory_physical_reserve(unsigned int start, unsigned int length)
                  ((start + length) <= (node->start + node->busy_length + node->free_length)))
         {
             insert_node = avl_node_allocate(page_avl_header);
-            avl_node_reset(insert_node, start, length,
-                           node->start + node->busy_length + node->free_length - start - length, NULL);
+            avl_node_reset(insert_node, start, length, node->start + node->busy_length + node->free_length - start - length,
+                           NULL, description);
 
             node->free_length = start - node->start - node->busy_length;
 
@@ -182,7 +174,7 @@ return_type memory_physical_reserve(unsigned int start, unsigned int length)
 }
 
 // Allocate some pages.
-return_type memory_physical_allocate(u32 *page, unsigned int length, char *description UNUSED)
+return_type memory_physical_allocate(u32 *page, unsigned int length, const char *description)
 {
     avl_node_type *node = page_avl_header->root;
     avl_node_type *insert_node;
@@ -227,6 +219,7 @@ return_type memory_physical_allocate(u32 *page, unsigned int length, char *descr
             {
                 node->busy_length = length;
                 node->free_length -= length;
+                node->description = description;
 
                 DEBUG_MESSAGE(DEBUG, "Special case!\n");
 
@@ -246,7 +239,8 @@ return_type memory_physical_allocate(u32 *page, unsigned int length, char *descr
             else
             {
                 insert_node = avl_node_allocate(page_avl_header);
-                avl_node_reset(insert_node, node->start + node->busy_length, length, node->free_length - length, NULL);
+                avl_node_reset(insert_node, node->start + node->busy_length, length, node->free_length - length, NULL,
+                               description);
                 //        debug_print ("evald = %u\n", node->start + node->busy_length);
 
                 node->free_length = 0;

--- a/storm/ia32/memory_physical.c
+++ b/storm/ia32/memory_physical.c
@@ -108,7 +108,7 @@ void memory_physical_init(void)
     for (counter = 0; counter < multiboot_info.number_of_modules; counter++)
     {
         memory_physical_reserve(GET_PAGE_NUMBER(multiboot_module_info[counter].start),
-            SIZE_IN_PAGES(multiboot_module_info[counter].end - multiboot_module_info[counter].start), "Server binaries");
+            SIZE_IN_PAGES(multiboot_module_info[counter].end - multiboot_module_info[counter].start), multiboot_module_info[counter].name);
     }
 }
 
@@ -164,7 +164,8 @@ return_type memory_physical_reserve(unsigned int start, unsigned int length, con
         else
         {
             // I smell something rotten in the land of England...
-            DEBUG_HALT("You tried to reserve something that was already taken.");
+            DEBUG_HALT("You tried to reserve %u pages starting at 0x%x, but they are already taken by %s", length,
+                       start * SIZE_PAGE, node->description);
             return RETURN_PAGE_NOT_FOUND;
         }
     }

--- a/storm/ia32/memory_physical.c
+++ b/storm/ia32/memory_physical.c
@@ -118,7 +118,8 @@ return_type memory_physical_reserve(unsigned int start, unsigned int length, con
     avl_node_type *node = page_avl_header->root;
     avl_node_type *insert_node;
 
-    DEBUG_MESSAGE(DEBUG, "start = %u, length = %u", start, length);
+    DEBUG_MESSAGE(DEBUG, "Reserving from 0x%x to 0x%x for %s", start * SIZE_PAGE, ((start + length) * SIZE_PAGE) - 1,
+                  description);
 
 #ifdef CHECK
     avl_debug_tree_check(page_avl_header, page_avl_header->root);

--- a/storm/ia32/memory_physical.c
+++ b/storm/ia32/memory_physical.c
@@ -34,7 +34,7 @@
 #include <storm/generic/thread.h>
 #include <storm/generic/types.h>
 
-u32 page_avl_base = BASE_PAGE_AVL;
+u32 page_avl_base;
 avl_header_type *page_avl_header;
 u32 pages_left, physical_pages;
 u32 page_avl_pages;
@@ -56,8 +56,11 @@ void memory_physical_init(void)
     page_avl_array_pages = SIZE_IN_PAGES(sizeof(avl_node_type) * physical_pages);
     page_avl_pages = page_avl_intro_pages + page_avl_array_pages;
 
+    // As demonstrated here, the AVL system is placed at the very end of the physical memory.
+    page_avl_base = (physical_pages - page_avl_pages) * SIZE_PAGE;
+
     // Put the AVL header where it should be.
-    page_avl_header = (avl_header_type *)(page_avl_base);
+    page_avl_header = (avl_header_type *) page_avl_base;
 
     // Fill in the values in the AVL header.
     page_avl_header->limit_nodes = physical_pages;
@@ -102,7 +105,7 @@ void memory_physical_init(void)
     memory_physical_reserve(GET_PAGE_NUMBER(BASE_UPPER), SIZE_IN_PAGES(SIZE_UPPER), "High memory");
 
     // Reserve the memory used by the AVL system.
-    memory_physical_reserve(GET_PAGE_NUMBER((u32) page_avl_header), page_avl_pages, "Physical memory AVL data");
+    memory_physical_reserve(GET_PAGE_NUMBER(page_avl_base), page_avl_pages, "Physical memory AVL data");
 
     // And of course the server images too.
     for (counter = 0; counter < multiboot_info.number_of_modules; counter++)

--- a/storm/ia32/memory_virtual.c
+++ b/storm/ia32/memory_virtual.c
@@ -1,5 +1,5 @@
 // Abstract: Provides functions for managing the virtual memory (MMU) mechanisms of the IA32 architecture.
-// Authors: Per Lundberg <per@halleluja.nu> 
+// Authors: Per Lundberg <per@halleluja.nu>
 //          Henrik Hallin <hal@chaosdev.org>
 
 // Copyright 1999-2000 chaos development.
@@ -82,7 +82,7 @@ void memory_virtual_init (void)
   /* FIXME: Check return value. */
 
   memory_physical_allocate (&physical_page,
-                            (GET_PAGE_NUMBER (SIZE_GLOBAL) / 1024), 
+                            (GET_PAGE_NUMBER (SIZE_GLOBAL) / 1024),
                             "Shared page table");
 
   shared_page_tables = (page_table_entry *) (physical_page * SIZE_PAGE);
@@ -112,19 +112,19 @@ void memory_virtual_init (void)
 
   memory_virtual_map_kernel
     (kernel_page_directory, GET_PAGE_NUMBER (BASE_PROCESS_PAGE_DIRECTORY),
-     GET_PAGE_NUMBER ((u32) kernel_page_directory), 
+     GET_PAGE_NUMBER ((u32) kernel_page_directory),
      1, PAGE_KERNEL);
 
   /* Kernel stack. */
-  
-  memory_virtual_map_kernel 
+
+  memory_virtual_map_kernel
     (kernel_page_directory, GET_PAGE_NUMBER (BASE_KERNEL_STACK),
      GET_PAGE_NUMBER (BASE_KERNEL_STACK), SIZE_IN_PAGES (SIZE_KERNEL_STACK),
      PAGE_KERNEL);
 
   /* Trap handler stack. */
 
-  //  memory_virtual_map_kernel 
+  //  memory_virtual_map_kernel
   //    (kernel_page_directory, GET_PAGE_NUMBER (BASE_TRAP_STACK),
   //     GET_PAGE_NUMBER (BASE_TRAP_STACK), SIZE_IN_PAGES (SIZE_TRAP_STACK),
   //     PAGE_KERNEL, PROCESS_ID_KERNEL);
@@ -133,7 +133,7 @@ void memory_virtual_init (void)
   /* FIXME: this should be done by some kind of log-server? */
 
   memory_virtual_map_kernel
-    (kernel_page_directory, GET_PAGE_NUMBER (BASE_SCREEN), 
+    (kernel_page_directory, GET_PAGE_NUMBER (BASE_SCREEN),
      GET_PAGE_NUMBER (BASE_SCREEN), 16, PAGE_KERNEL);
 
   /* Multiboot module names. */
@@ -144,8 +144,8 @@ void memory_virtual_init (void)
      GET_PAGE_NUMBER (BASE_MODULE_NAME), 1, PAGE_KERNEL);
 
   /* Kernel code and data. */
-  
-  memory_virtual_map_kernel 
+
+  memory_virtual_map_kernel
     (kernel_page_directory, GET_PAGE_NUMBER (BASE_KERNEL),
      GET_PAGE_NUMBER (BASE_KERNEL), SIZE_IN_PAGES ((u32) &_end - BASE_KERNEL),
      PAGE_KERNEL);
@@ -155,7 +155,7 @@ void memory_virtual_init (void)
   for (counter = 0; counter < SIZE_IN_PAGES (SIZE_GLOBAL) / 1024; counter++)
   {
     u32 index = (GET_PAGE_NUMBER (BASE_GLOBAL) / 1024) + counter;
-    
+
     kernel_page_directory[index].present = 1;
     kernel_page_directory[index].flags = PAGE_DIRECTORY_FLAGS;
     kernel_page_directory[index].accessed = 0;
@@ -173,7 +173,7 @@ void memory_virtual_init (void)
     {
       kernel_page_directory[index].global = 0;
     }
-    
+
     kernel_page_directory[index].available = 0;
     kernel_page_directory[index].page_table_base =
       (GET_PAGE_NUMBER (shared_page_tables) + counter);
@@ -194,7 +194,7 @@ void memory_virtual_enable (void)
 {
   //  debug_print
   //    ("Would save %u K of memory.\n",
-  //     ((page_avl_header->limit_nodes - 
+  //     ((page_avl_header->limit_nodes -
   //       avl_get_number_of_entries (page_avl_header->root)) *
   //      sizeof (avl_node_type)) / KB + 12 +
   //     ((u32) &_init_end - (u32) &_init_start) / KB);
@@ -202,14 +202,14 @@ void memory_virtual_enable (void)
   DEBUG_MESSAGE (DEBUG, "Called");
 
   /* Map the kernel TSS. */
-  
+
   memory_virtual_map_kernel
     (kernel_page_directory, GET_PAGE_NUMBER (BASE_VIRTUAL_KERNEL_TSS),
      GET_PAGE_NUMBER (BASE_KERNEL_TSS), 1, PAGE_KERNEL);
 
   /* Map global data in the shared page tables. Since the page tables are the
      same for all processes, we can just map for the kernel. */
-  
+
   /* FIXME: need to find out how many pages are in use. */
 
   memory_virtual_map_kernel
@@ -222,20 +222,20 @@ void memory_virtual_enable (void)
 
   avl_tree_move (page_avl_header, BASE_PHYSICAL_MEMORY_TREE -
                  (u32) page_avl_header);
-  
+
   page_avl_header = (avl_header_type *) BASE_PHYSICAL_MEMORY_TREE;
 
   /* FIXME: Do this funky music, d0od. */
 
   /* Unreserve all the memory used by the page allocation system. */
-  
+
   //  page_range_unreserve (whatever);
 
   /* ...and reserve the parts needed. */
 
   /* Specify page directory to use for the kernel. */
 
-  cpu_set_cr3 ((u32) kernel_page_directory); 
+  cpu_set_cr3 ((u32) kernel_page_directory);
 
   /* Enable paging (virtual memory), protection and set the extension
      type flag. No external datastructures can be accessed after
@@ -273,11 +273,11 @@ return_type memory_virtual_map_kernel
   u32 counter, index;
 
   for (counter = 0; counter < pages; counter++)
-  {  
+  {
     /* Which page table? */
 
     index = (virtual_page + counter) / 1024;
-    
+
     if (page_directory[index].present == 0)
     {
       u32 page_table_page;
@@ -296,20 +296,20 @@ return_type memory_virtual_map_kernel
       page_directory[index].global = 0;
       page_directory[index].available = 0;
       page_directory[index].page_table_base = page_table_page;
-      
+
       /* Make sure we could allocate memory. */
 
       if (page_directory[index].page_table_base == 0)
       {
       	return RETURN_OUT_OF_MEMORY;
       }
-      
+
       /* Make sure no pages in the new page table are marked as
          present. */
 
       page_table = (page_table_entry *)
         (page_directory[index].page_table_base * SIZE_PAGE);
-      memory_set_u8 ((u8 *) page_table, 0, SIZE_PAGE); 
+      memory_set_u8 ((u8 *) page_table, 0, SIZE_PAGE);
 
       /* Map the newly created page table in the page_directory. */
 
@@ -324,9 +324,9 @@ return_type memory_virtual_map_kernel
     }
 
     /* Which entry in the page table to modify. */
-    
+
     index = (virtual_page + counter) % 1024;
-    
+
     /* Set up a new page table entry. */
 
     page_table[index].present = 1;
@@ -343,20 +343,20 @@ return_type memory_virtual_map_kernel
 
 /* This function is for mapping memory in syscalls (when paging is
    enabled). */
-  
+
 static return_type memory_virtual_map_real
   (u32 virtual_page, u32 physical_page, u32 pages, u32 flags)
 {
   page_table_entry *page_table;
   u32 counter, index;
 
-  DEBUG_MESSAGE (DEBUG, "Called (%x, %x, %x, %x)", virtual_page, 
+  DEBUG_MESSAGE (DEBUG, "Called (%x, %x, %x, %x)", virtual_page,
                  physical_page, pages, flags);
 
   for (counter = 0; counter < pages; counter++)
-  {  
+  {
     index = (virtual_page + counter) / 1024;
-    
+
     DEBUG_MESSAGE (DEBUG, "index = %u, counter = %u", index, counter);
 
     if (process_page_directory[index].present == 0)
@@ -382,9 +382,9 @@ static return_type memory_virtual_map_real
 
       //      memory_virtual_cache_invalidate
       //        ((void *) (process_page_directory[index].page table_base * SIZE_PAGE));
-      
+
       /* Make sure we could allocate memory. */
-      
+
       if (process_page_directory[index].page_table_base == 0)
       {
         return RETURN_OUT_OF_MEMORY;
@@ -397,12 +397,12 @@ static return_type memory_virtual_map_real
          (u32) process_page_directory[index].page_table_base, 1, PAGE_KERNEL);
 
       memory_set_u8 ((u8 *) (BASE_PROCESS_PAGE_TABLES + (index * SIZE_PAGE)),
-                     0, SIZE_PAGE); 
+                     0, SIZE_PAGE);
     }
 
     /* The page table is in the page_directory. */
 
-    
+
     page_table = (page_table_entry *)
       (BASE_PROCESS_PAGE_TABLES + (index * SIZE_PAGE));
 
@@ -452,7 +452,7 @@ static return_type memory_virtual_map_other_real
     (BASE_PROCESS_TEMPORARY + SIZE_PAGE);
   u32 counter, index;
   bool global = (flags & PAGE_GLOBAL) != 0;
-  
+
   /* Remove PAGE_GLOBAL from the flags, if set. */
 
   flags &= ~PAGE_GLOBAL;
@@ -469,9 +469,9 @@ static return_type memory_virtual_map_other_real
   /* Start the mapping. */
 
   for (counter = 0; counter < pages; counter++)
-  {  
+  {
     index = (virtual_page + counter) / 1024;
-    
+
     DEBUG_MESSAGE (DEBUG, "Changing page directory entry %x", index);
 
     /* Page Table is not set up yet. */
@@ -496,9 +496,9 @@ static return_type memory_virtual_map_other_real
       page_directory[index].global = 0;
       page_directory[index].available = 0;
       page_directory[index].page_table_base = page_table_page;
-      
+
       /* Make sure we could allocate memory. */
-      
+
       //      if (process_page_directory[index].page table_base == 0)
       //      {
       //	return RETURN_OUT_OF_MEMORY;
@@ -513,7 +513,7 @@ static return_type memory_virtual_map_other_real
       memory_virtual_map_real
         (GET_PAGE_NUMBER (page_table),
          (u32) page_directory[index].page_table_base, 1, PAGE_KERNEL);
-      memory_set_u8 ((u8 *) page_table, 0, SIZE_PAGE); 
+      memory_set_u8 ((u8 *) page_table, 0, SIZE_PAGE);
     }
 
     memory_virtual_map_real
@@ -536,9 +536,9 @@ static return_type memory_virtual_map_other_real
     page_table[index].available = 0;
     page_table[index].page_base = physical_page + counter;
 
-    if (global) 
+    if (global)
     {
-      page_table[index].global = 1; 
+      page_table[index].global = 1;
     }
   }
 
@@ -555,7 +555,7 @@ return_type memory_virtual_map
 {
   return_type return_value;
 
-  DEBUG_MESSAGE (DEBUG, "Mapping %x at %x (%u pages)", physical_page, 
+  DEBUG_MESSAGE (DEBUG, "Mapping %x at %x (%u pages)", physical_page,
                  virtual_page, pages);
 
   //  mutex_kernel_wait (&memory_map_mutex);
@@ -598,9 +598,9 @@ void memory_virtual_unmap (u32 virtual_page, u32 pages)
   u32 counter, index;
 
   //  mutex_kernel_wait (&memory_map_mutex);
-  
+
   for (counter = 0; counter < pages; counter++)
-  {  
+  {
     index = (virtual_page + counter) / 1024;
 
     if (process_page_directory[index].present != 0)
@@ -644,7 +644,7 @@ return_type map (process_id_type process_id, u32 virtual_page,
 
   DEBUG_MESSAGE (DEBUG, "linear_page: 0x%lX, physical_page: 0x%lX, pages: %lu\n", linear_page,
                  physical_page, pages);
-  
+
   if (task > number_of_threads)
   {
     return RETURN_THREAD_INVALID;
@@ -666,13 +666,13 @@ return_type memory_virtual_allocate (u32 *page_number, u32 pages)
   avl_node_type *node = process_avl_header->root;
   avl_node_type *insert_node;
 
-  if (tss_tree_mutex != MUTEX_LOCKED && 
+  if (tss_tree_mutex != MUTEX_LOCKED &&
       memory_mutex != MUTEX_LOCKED && initialised)
   {
     DEBUG_HALT ("Code is not properly mutexed.");
   }
 
-  DEBUG_MESSAGE (DEBUG, "Called with page_number = %p, pages = %u", page_number, 
+  DEBUG_MESSAGE (DEBUG, "Called with page_number = %p, pages = %u", page_number,
                  pages);
 
   DEBUG_MESSAGE (DEBUG, "p: %p, r00t: %p, l: %u", process_avl_header,
@@ -726,13 +726,15 @@ return_type memory_virtual_allocate (u32 *page_number, u32 pages)
       else
       {
         insert_node = avl_node_allocate (process_avl_header);
-        avl_node_reset (insert_node, node->start + node->busy_length,
-                        pages, node->free_length - pages, NULL);
-        
+
+        // TODO: Make the description here configurable by the caller.
+        avl_node_reset (insert_node, node->start + node->busy_length, pages, node->free_length - pages, NULL,
+                        "Virtual memory (allocated)");
+
         node->free_length = 0;
-        
+
         avl_update_tree_largest_free (node->parent);
-        
+
         avl_node_insert (process_avl_header, insert_node);
 
         DEBUG_MESSAGE (DEBUG, "Exiting");
@@ -770,7 +772,7 @@ return_type memory_virtual_deallocate (u32 page_number)
   avl_node_type *node = process_avl_header->root;
   avl_node_type *adjacent_node;
   bool finished = FALSE;
-  
+
 #ifdef CHECK
   avl_debug_tree_check (process_avl_header, process_avl_header->root);
 #endif
@@ -832,7 +834,7 @@ return_type memory_virtual_deallocate (u32 page_number)
   {
     node->free_length += node->busy_length;
     node->busy_length = 0;
-    
+
     avl_update_tree_largest_free (node->parent);
   }
   else
@@ -880,7 +882,7 @@ return_type memory_virtual_reserve (unsigned int start_page,
     }
 
     /* Is it on the right side? */
-    
+
     else if (start_page >=
              (node->start + node->busy_length + node->free_length))
     {
@@ -894,9 +896,11 @@ return_type memory_virtual_reserve (unsigned int start_page,
               (node->start + node->busy_length + node->free_length)))
     {
       insert_node = avl_node_allocate (process_avl_header);
+
+      // TODO: Make it possible to override the description.
       avl_node_reset (insert_node, start_page, pages,
                       node->start + node->busy_length +
-                      node->free_length - start_page - pages, NULL);
+                      node->free_length - start_page - pages, NULL, "Virtual memory (reserved)");
 
       node->free_length = start_page - node->start - node->busy_length;
 
@@ -926,7 +930,7 @@ return_type memory_virtual_reserve (unsigned int start_page,
   }
 
   /* We didn't find a match. This will normally never happen. */
-  
+
   DEBUG_HALT ("Couldn't find a match");
   return RETURN_PAGE_NOT_FOUND;
 }

--- a/storm/ia32/multiboot.c
+++ b/storm/ia32/multiboot.c
@@ -29,8 +29,8 @@ void INIT_CODE multiboot_init (void)
     // in the boot process.
     for (module = 0; module < multiboot_info.number_of_modules; module++)
     {
-        string_copy (target, (char *) multiboot_module_info[module].name);
-        multiboot_module_info[module].name = (u8 *) target;
+        string_copy(target, multiboot_module_info[module].name);
+        multiboot_module_info[module].name = target;
         target += string_length (target) + 1;
     }
 

--- a/storm/ia32/process.c
+++ b/storm/ia32/process.c
@@ -415,7 +415,7 @@ return_type process_create(process_create_type *process_data)
       (avl_node_type *) (BASE_PROCESS_CREATE + 1 * SIZE_PAGE);
 
     // The lowest 4 megs are reserved for kernel and other stuff.
-    avl_node_reset(new_avl_header->root, 0, 1024, MAX_PAGES - 1024, NULL);
+    avl_node_reset(new_avl_header->root, 0, 1024, MAX_PAGES - 1024, NULL, "Reserved for kernel");
 
     new_avl_header->root = new_avl_header->node_array =
        (avl_node_type *) (BASE_PROCESS_AVL_TREE + process_avl_intro_pages * SIZE_PAGE);

--- a/storm/include/storm/generic/avl.h
+++ b/storm/include/storm/generic/avl.h
@@ -18,6 +18,8 @@ typedef struct avl_node_type
     // Pointer to parent.
     struct avl_node_type *parent;
 
+    const char *description;
+
     // Which of the child-trees is the highest?
     int balance;
 
@@ -29,7 +31,7 @@ typedef struct avl_node_type
     unsigned int busy_length;
     unsigned int free_length;
 
-    // These two make the search for a free block very fast.
+    // These two make the search for a free block very fast, but causes more work whenever the tree is updated.
     unsigned int largest_free_less;
     unsigned int largest_free_more;
 } __attribute__((packed)) avl_node_type;
@@ -68,7 +70,7 @@ typedef struct
 
 // Function prototypes.
 extern void avl_node_reset(avl_node_type *node, unsigned int start, unsigned int busy_length, unsigned int free_length,
-                           avl_node_type *parent);
+                           avl_node_type *parent, const char *description);
 extern avl_node_type *avl_node_allocate(avl_header_type *avl_header);
 extern void avl_tree_move(avl_header_type *avl_header, unsigned int delta);
 extern void avl_node_insert(avl_header_type *avl_header, avl_node_type *insert_node);

--- a/storm/include/storm/generic/memory_physical.h
+++ b/storm/include/storm/generic/memory_physical.h
@@ -12,8 +12,8 @@
 
 extern void memory_physical_init(void) INIT_CODE;
 
-extern return_type memory_physical_reserve(unsigned int start, unsigned int length);
-extern return_type memory_physical_allocate(u32 *page, unsigned int length, char *description) WEAK;
+extern return_type memory_physical_reserve(unsigned int start, unsigned int length, const char *description);
+extern return_type memory_physical_allocate(u32 *page, unsigned int length, const char *description) WEAK;
 extern return_type memory_physical_deallocate(unsigned int start);
 extern u32 memory_physical_get_number_of_pages(void);
 extern u32 memory_physical_get_free(void);

--- a/storm/include/storm/generic/multiboot.h
+++ b/storm/include/storm/generic/multiboot.h
@@ -94,7 +94,7 @@ typedef struct
 {
     u32 start;
     u32 end;
-    u8 *name;
+    char *name;
     u32 reserved;
 } PACKED multiboot_module_info_type;
 

--- a/storm/include/storm/ia32/defines.h
+++ b/storm/include/storm/ia32/defines.h
@@ -32,9 +32,6 @@
 #define BASE_UPPER                      (640 * KB)
 #define BASE_SCREEN                     (0xB8000)
 
-// FIXME!!! The AVL tree should be at the end of physical memory.
-#define BASE_PAGE_AVL                   (3 * MB + 512 * KB)
-
 // Virtual addresses.
 #define BASE_VIRTUAL_KERNEL_TSS         (40 * KB)
 


### PR DESCRIPTION
Previously, the physical AVL tree was *hardwired* to be at 3,5 MiB in the physical memory, i.e. making it (theoretically) possible to run on 4 MiB machines. This had the severe limitation that it was really hard to make servers that are bigger than a few megabytes.

I don't like that, and I'm currently (in #35) experiencing weird issues related to the AVL reservations, so I thought I'd fix this.

As an extra bonus, this PR adds a description field to all AVL nodes. This makes it a **lot** easier to try and debug cases when AVL nodes overlap. (Yes, I am aware of the risk that the description string could be located in memory locations which are not in global memory, when speaking about user-level memory allocation. We may have to fix that at some point.)

/cc @CaspecoHenrik - thanks for a tiny bit of moral support when debugging this. :smile: 