### PR TITLE
Added .gitattributes to force LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Autodetect text files
+* text=auto
+ 
+# Force the following filetypes to have unix EOLs, so Windows does not break them
+*.* text eol=lf


### PR DESCRIPTION
The reason here is to prevent Windows from adding CRLF line endings. Inspired by this gist: https://gist.github.com/ArminVieweg/c0fe55fe2fb25cd44772

What do you think @CaspecoHenrik - doesn't this seem like the most reasonable way to do it?
