### PR TITLE
//ramdisk/config/servers/boot/startup not found

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,10 @@ end
 desc 'Creates the initial ramdisk image where the programs and their data is stored'
 task :create_ramdisk_image do
   sh "cd servers/block/initial_ramdisk && #{RAKE_COMMAND} create_ramdisk_image"
+
+  sh 'mmd -o u:/config'
+  sh 'mmd u:/config/servers'
+  sh 'mmd u:/config/servers/boot'
 end
 
 desc 'Compiles and installs chaos'

--- a/menu.lst
+++ b/menu.lst
@@ -7,7 +7,7 @@ module /servers/console.gz
 module /servers/keyboard.gz
 module /servers/vga.gz
 module /servers/log.gz
-module /servers/virtual_file_system.gz
-module /servers/fat.gz
 module /servers/initial_ramdisk.gz
+module /servers/fat.gz
+module /servers/virtual_file_system.gz
 module /servers/boot.gz

--- a/servers/file_system/virtual_file_system/virtual_file_system.c
+++ b/servers/file_system/virtual_file_system/virtual_file_system.c
@@ -234,6 +234,7 @@ static void vfs_file_get_info(file_verbose_directory_entry_type *directory_entry
 
     if (volume == mounted_volumes || volume == (unsigned int) -1)
     {
+        log_print_formatted(&log_structure, LOG_URGENCY_WARNING, "Failed to found matching volume for %s", directory_entry->path_name);
         directory_entry->success = FALSE;
         return;
     }
@@ -306,6 +307,7 @@ static void vfs_file_get_info(file_verbose_directory_entry_type *directory_entry
                 // Did the file not exist?
                 if (input_index == mounted_volumes)
                 {
+                    log_print_formatted(&log_structure, LOG_URGENCY_DEBUG, "Failed to find %s in meta-root filesystem", directory_entry->path_name);
                     directory_entry->success = FALSE;
                     return;
                 }


### PR DESCRIPTION
This is an attempt to work in a systematic way with trying to nail down this issue...

When booting up `chaos` now, I get this error:

                                   [boot] beginning of boot
                                   [boot] Mounted the first available block service as //ramdisk.
                                   [boot] Reading startup script...
                                   [virtual_file_system] Mounting 23 at //ramdisk.
                                   [boot] //ramdisk/config/servers/boot/startup not found.

My conclusions thus far:

- The boot server is responsible both for mounting the file system (from the initial ramdisk) and reading its file. The former seems to work, the latter seems to fail.
- The FAT server (which should be serving this filesystem) never seems to get any messages, which seem to indicate that the connection between VFS and individual file systems are broken somehow. To me right now, it feels unclear how this work: what is it that determines what file system server should be used for a given mount point?
- When trying to debug the vfs server, I've placed breakpoints in `vfs_get_file_info` to try and step through the code. However, it's been an **extremely** unpleasant situation trying to get my hands dirty on this one. Because of chaos multiprocess/multi-threaded nature, stepping in the debugger will make things "jump around" very much, making it really really hard to understand what's going on.

So I think:

1. Either we have to fix `gdb` to properly understand our process/thread model. Probably doable, amount of work unknown **OR**
2. Resort to `printf` style debugging, i.e. `log_print_formatted`. This is the approach I'm leaning towards and which I've tried to a certain points.

Comments/suggestions/ideas from all of you are *highly* appreciated. This bug is really bothering me, and it's frustrating to not understand the code that we wrote 15 years ago... :smile: 