### PR TITLE
Make cluido wait for ipv4 to become available

### DIFF
--- a/libraries/ipv4/ipv4.c
+++ b/libraries/ipv4/ipv4.c
@@ -16,7 +16,7 @@ return_type ipv4_init(ipc_structure_type *ipv4_structure, tag_type *tag)
     unsigned int services = 10;
 
     // Try to resolve the IPv4 service.
-    if (ipc_service_resolve("ipv4", mailbox_id, &services, 0, tag) != IPC_RETURN_SUCCESS)
+    if (ipc_service_resolve("ipv4", mailbox_id, &services, 5, tag) != IPC_RETURN_SUCCESS)
     {
         return IPV4_RETURN_SERVICE_UNAVAILABLE;
     }

--- a/programs/cluido/command.c
+++ b/programs/cluido/command.c
@@ -99,6 +99,12 @@ int number_of_commands = (sizeof(command) / sizeof(command_type));
 // Show the entries in the ARP table.
 void command_arp(int number_of_arguments UNUSED, char **argument UNUSED)
 {
+    if (!has_net)
+    {
+      console_print_formatted(&console_structure, "\nNetworking is not available. Is the 'ipv4' server running?\n\n");
+      return;
+    }
+
     message_parameter_type message_parameter;
     int amount;
     int counter;
@@ -488,6 +494,12 @@ void command_help(int number_of_arguments, char **argument)
 // Configure IP networking.
 void command_ip(int number_of_arguments, char **argument)
 {
+    if (!has_net)
+    {
+      console_print_formatted(&console_structure, "\nNetworking is not available. Is the 'ipv4' server running?\n\n");
+      return;
+    }
+
     // If no arguments are given, print information about the current interfaces.
     if (number_of_arguments == 1)
     {

--- a/programs/cluido/init.c
+++ b/programs/cluido/init.c
@@ -35,6 +35,9 @@ int main(void)
         return -1;
     }
 
+    // We may be running as a "service" until the boot server has been fixed, so for now, let's unblock the next server.
+    system_call_process_parent_unblock();
+
     file_init(&vfs_structure, &empty_tag);
     memory_init();
 
@@ -82,9 +85,6 @@ with a movable mouse cursor.\n\
 Some Emacs compatible bindings (C-a, C-e, etc) are available, and also some\n\
 DOS:ish ones (Home, End, arrows). You can go back and forth in the command\n\
 history with the up and down arrows.\n\n");
-
-    // We may be running as a "service" until the boot server has been fixed, so for now, let's unblock the next server.
-    system_call_process_parent_unblock();
 
     main_loop();
     return 0;

--- a/programs/cluido/init.c
+++ b/programs/cluido/init.c
@@ -63,7 +63,7 @@ you for your time and interest in the project.\n");
 
     console_print(&console_structure, "\
 \n\
-\e[1mcluido version 0.0.2, Copyright (c) 1998-2000, 2015 chaos development.\n\
+\e[1mcluido version 0.0.3, Copyright (c) 1998-2000, 2015 chaos development.\n\
 cluido and the rest of chaos comes with ABSOLUTELY NO WARRANTY.\n\
 chaos is free software, and you are welcome to redistribute it under\n\
 certain conditions; see the README.md file for details.\e[0;44m\n");


### PR DESCRIPTION
Quite simple stuff. This means that you can have `cluido` start before `ipv4`, and still have `cluido` be able to locate the `ipv4` server - which I find nice. It would be easiest to just put `cluido` last in the list of things to start, but the virtual consoles seems to get a bit messed up if doing that, so let's not do it like that *for now* at least...

(Eventually, the boot server should be completed and the responsibility for starting up cluido should be handed over to it. I'm not 100% sure that the building blocks - be able to start ELF binaries from user processes, etc - are in place, but they **should** be since we do have an execute command in cluido... Worth checking out at some point, it is.)