### PR TITLE
cluido: Fixed the 'top' command to display the correct process name

### DIFF
--- a/programs/cluido/command.c
+++ b/programs/cluido/command.c
@@ -1221,7 +1221,7 @@ void command_top(int number_of_arguments UNUSED, char *argument[] UNUSED)
              kernelfs_thread_info.thread_number++)
         {
             system_call_kernelfs_entry_read(&kernelfs_thread_info);
-            kernelfs_thread_info.process_name[15] = '\0';
+            kernelfs_process_info.name[15] = '\0';
             kernelfs_thread_info.thread_name[15] = '\0';
             console_print_formatted(&console_structure,
                                     "%-8lu %-8lu %-8lu %-8lu %08lX %-15s %-15s\n",
@@ -1231,7 +1231,7 @@ void command_top(int number_of_arguments UNUSED, char *argument[] UNUSED)
                                     kernelfs_thread_info.main_memory / 1024,
                                     /* kernelfs_thread_info.stack_memory / 1024, */
                                     kernelfs_thread_info.instruction_pointer,
-                                    kernelfs_thread_info.process_name,
+                                    kernelfs_process_info.name,
                                     kernelfs_thread_info.thread_name);
         }
     }

--- a/storm/generic/kernelfs.c
+++ b/storm/generic/kernelfs.c
@@ -2,9 +2,12 @@
 // easily available to regular user processes.
 
 // Authors: Per Lundberg <per@halleluja.nu>
-//            Henrik Hallin <hal@chaosdev.org>
+//          Henrik Hallin <hal@chaosdev.org>
 
-// © Copyright 1999-2000, 2007, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2007 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #define DEBUG FALSE
 

--- a/storm/generic/kernelfs.c
+++ b/storm/generic/kernelfs.c
@@ -179,8 +179,6 @@ return_type kernelfs_entry_read(kernelfs_generic_type *kernelfs_generic)
                 {
                     if (thread == thread_info->thread_number)
                     {
-                        //            string_copy (thread_info->process_name,
-                        //                         tss_node->tss->process_name);
                         string_copy(thread_info->thread_name, tss_node->tss->thread_name);
 
                         thread_info->thread_id = tss_node->tss->thread_id;

--- a/storm/include/storm/kernelfs.h
+++ b/storm/include/storm/kernelfs.h
@@ -2,7 +2,9 @@
 // Authors: Per Lundberg <per@halleluja.nu>
 //          Henrik Hallin <hal@chaosdev.org>
 
-// © Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2015 chaos development
 
 #pragma once
 

--- a/storm/include/storm/kernelfs.h
+++ b/storm/include/storm/kernelfs.h
@@ -100,7 +100,6 @@ typedef struct
     u32 main_memory;
     u32 stack_memory;
 
-    char process_name[MAX_PROCESS_NAME_LENGTH];
     char thread_name[MAX_THREAD_NAME_LENGTH];
 
     // The current instruction pointer of the thread.


### PR DESCRIPTION
Subject says it all. We removed the `process_name` field from the `kernelfs_thread_info_verbose_type` structure altogether; the user will have to get the process info instead if they want to read out the process name.