### PR TITLE
Changed to 32 bit Vagrant box

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,12 +39,10 @@ end
 
 desc 'Builds a bootable ISO image with the kernel, servers and programs.'
 task :iso_image do
-
   FileUtils.mkdir_p "#{INSTALL_ROOT}/boot/grub"
   FileUtils.cp 'menu.lst', "#{INSTALL_ROOT}/boot/grub"
 
-  # I suspect this is actually an x86 binary, even though it resides in a folder that seems to indicate the opposite.
-  FileUtils.cp '/usr/lib/grub/x86_64-pc/stage2_eltorito', "#{INSTALL_ROOT}/boot/grub"
+  FileUtils.cp '/usr/lib/grub/i386-pc/stage2_eltorito', "#{INSTALL_ROOT}/boot/grub"
 
   print 'Creating ISO image...'.cyan.bold
   sh "genisoimage \
@@ -85,4 +83,3 @@ end
 task :servers do |folder|
   sh "cd #{folder} && rake"
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,10 @@ task :iso_image do
   FileUtils.mkdir_p "#{INSTALL_ROOT}/boot/grub"
   FileUtils.cp 'menu.lst', "#{INSTALL_ROOT}/boot/grub"
 
-  FileUtils.cp '/usr/lib/grub/i386-pc/stage2_eltorito', "#{INSTALL_ROOT}/boot/grub"
+  eltorito_file = '/usr/lib/grub/i386-pc/stage2_eltorito'
+  eltorito_file = '/usr/lib/grub/x86_64-pc/stage2_eltorito' unless File.exist? eltorito_file
+
+  FileUtils.cp eltorito_file, "#{INSTALL_ROOT}/boot/grub"
 
   print 'Creating ISO image...'.cyan.bold
   sh "genisoimage \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure(2) do |config|
   config.vm.provider :parallels do |vb, override|
-    override.vm.box = 'puphpet/debian75-x64'
+    override.vm.box = 'puphpet/debian75-x32'
   end
 
   config.vm.provider :virtualbox do |vb, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.provider :parallels do |vb, override|
-    override.vm.box = 'puphpet/debian75-x32'
-  end
-
-  config.vm.provider :virtualbox do |vb, override|
-    config.vm.box = 'chef/debian-7.8'
-  end
+  config.vm.box = 'puphpet/debian75-x32'
 
   config.vm.provision 'shell', inline: <<-SHELL
     set -e


### PR DESCRIPTION
This is a preparational PR to be able to write chaos servers & programs in Rust. (Yes, really. :smile:)

(Background: if we have a 64-bit VM, the `rustc` compiler will default to 64-bit `.o` files in its compilation. It is quite likely that it can be overridden, but for simplicity, let's just switch to 32-bit. There's no compelling reason for us to run the Vagrant  box in 64-bit mode anyway.)