### PR TITLE
Added very basic support for Rust compilation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,10 @@ Vagrant.configure(2) do |config|
       qemu \
       rake
 
+    # We need the beta channel for the #![feature] functionality.
+    curl -sSf https://static.rust-lang.org/rustup.sh > /tmp/rustup.sh && \
+      sh /tmp/rustup.sh --yes --channel=beta
+
     cd /vagrant
     ./install_cmocka.sh
 

--- a/rakelib/common_rules.rake
+++ b/rakelib/common_rules.rake
@@ -9,6 +9,17 @@ rule '.o' => [ '.c' ] do |t|
   end
 end
 
+rule '.o' => [ '.rs' ] do |t|
+  begin
+    print((t.source + ' ').cyan)
+    command = "#{RUSTC} #{RUSTCFLAGS} --crate-type lib -o #{t.name} --emit obj #{t.source}"
+    sh command
+  rescue
+    puts "Error compiling #{t.source}. Full command line was: #{command}"
+    raise
+  end
+end
+
 rule '.o' => [ '.S' ] do |t|
   begin
     print((t.source + ' ').cyan)

--- a/rakelib/common_settings.rake
+++ b/rakelib/common_settings.rake
@@ -8,6 +8,8 @@ when 'Darwin' then
 else
   CC = ENV['CC'] || 'gcc-4.7'
   AR = ENV['AR'] || 'ar'
+  RUSTC = 'rustc'
+  RUSTCFLAGS = '-O -C code-model=kernel -C relocation-model=static'
 end
 
 # Can always use plain nasm, since even the OSX version can produce ELF images.


### PR DESCRIPTION
As many of you already know, [Rust](https://www.rust-lang.org/) is a new programming language. It is yet quite young and "unstable" in a sense (version 1.0 was released just a few months ago). Nonetheless, it "looks promising" and may be a suitable choice for writing chaos servers and programs in. This PR adds *very basic* support for it; it adds `.rs` file compilation and downloads the Rust beta when the Vagrant box is provisioned.

**Note**: The idea is not (at this point) to rewrite or re-think the whole of chaos in Rust. That is an **extremely** large project (albeit an interesting one, I must admit :wink:). The aim at this stage is more to *make it possible* (and simple) to start writing *some* of the new stuff in Rust instead of the (very!) awkward thing that C and C++ IMHO happen to be...