### PR TITLE
Updated to gcc version 5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ root = pwd
 Rake.application.options.rakelib = ["#{root}/rakelib"]
 
 desc 'Compiles chaos'
-task :default => [:create_ramdisk_image] + FOLDERS + [:iso_image]
+task :default => [:create_ramdisk_image] + FOLDERS
 
 desc 'Performs cleanup (removes old .o files and similar)'
 task :clean do

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,13 +1,14 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = 'puphpet/debian75-x32'
+  config.vm.box = 'remram/debian-9-i386'
 
   config.vm.provision 'shell', inline: <<-SHELL
     set -e
     sudo apt-get update
-    sudo apt-get install -y \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
       astyle \
       cmake \
       dosfstools \
+      gcc-5 \
       gcc-multilib \
       gdb \
       genisoimage \

--- a/rakelib/common_settings.rake
+++ b/rakelib/common_settings.rake
@@ -6,7 +6,7 @@ case UNAME
 when 'Darwin' then
   abort 'Error: OS X is not supported as a build host.'
 else
-  CC = ENV['CC'] || 'gcc-4.7'
+  CC = ENV['CC'] || 'gcc-5'
   AR = ENV['AR'] || 'ar'
   RUSTC = 'rustc'
   RUSTCFLAGS = '-O -C code-model=kernel -C relocation-model=static'

--- a/storm/ia32/dispatch.c
+++ b/storm/ia32/dispatch.c
@@ -37,7 +37,7 @@ volatile cluster_id_type current_cluster_id = CLUSTER_ID_KERNEL;
 volatile thread_id_type current_thread_id = THREAD_ID_KERNEL;
 volatile time_type timeslice = 0;
 storm_tss_type *current_tss = (storm_tss_type *) BASE_VIRTUAL_KERNEL_TSS;
-static u32 jump_data[2] = { 0, 0 };
+u32 jump_data[2] = { 0, 0 };
 tss_list_type *current_tss_node;
 
 void dispatch_init(void)
@@ -104,7 +104,7 @@ static int update_data(void)
         counter++;
         tss_node = (tss_list_type *) tss_node->next;
         if (tss_node == NULL)
-        {            
+        {
             tss_node = tss_list;
         }
     } while (tss_node->tss->state != STATE_DISPATCH);


### PR DESCRIPTION
The update takes place not because we *depend* on anything that is new in gcc-5, but it's still good practice to upgrade early to find out any potential issues, and also because gcc 5 will sooner or later be the default (presumably). In this case, the upgrade was very smooth and trouble-free, which is nice.

----

Details:

* Vagrantfile: Updated to Debian 9 (a.k.a. stretch), so we can get the gcc-5 package (it't not available in jessie, i.e. Debian 8).
* rakelib/common_settings.rake: Use gcc-5 as the compiler by default.
* Rakefile: Don't build the iso_image task by default, since it will have garbage content in that case. It doesn't make sense to build it before the binaries have been installed in the right place.
* storm/ia32/dispatch.c: gcc-5 is more aggressive in its optimizations, so the  variable gets optimized away if we provide it as static.