### PR TITLE
Use rust nightly from last night.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
 
     # We need the beta channel for the #![feature] functionality.
     curl -sSf https://static.rust-lang.org/rustup.sh > /tmp/rustup.sh && \
-      sh /tmp/rustup.sh --yes --channel=beta
+      sh /tmp/rustup.sh --yes --channel=nightly --date=2016-01-13
 
     cd /vagrant
     ./install_cmocka.sh


### PR DESCRIPTION
This fixes a problem with `libcore` and other things being uncompilable with the previous setup. The problem is that #[feature] isn't usable with the `beta` channel, so we really have to go with a nightly build instead to get stuff like that working.