### PR TITLE
Linter fixes, to be Rubocop clean

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,10 @@
 Metrics/LineLength:
   Max: 132
-Style/HashSyntax:
-  Enabled: false
 Style/AndOr:
   Enabled: false
 Style/AsciiComments:
   Enabled: false
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ before_script:
  - sudo apt-get install dosfstools gcc-multilib genisoimage grub mtools nasm
  - ./install_cmocka.sh
 script:
+ - bundle exec rubocop
  - rake
  - rake tests

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.2.0)
+    parser (2.3.0.3)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    rainbow (2.1.0)
+    rake (10.5.0)
+    rubocop (0.37.0)
+      parser (>= 2.3.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 0.3)
+    ruby-progressbar (1.7.5)
+    unicode-display_width (0.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  rubocop
+
+BUNDLED WITH
+   1.11.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
 # Top-level Rakefile which is responsible for running all the other Rakefiles.
 
 # TODO: Uncomment the rest here as soon as we have updated their build process to rake also.
-FOLDERS = [:storm, :libraries, :programs, :servers]
+FOLDERS = [:storm, :libraries, :programs, :servers].freeze
 
 verbose false
 
@@ -12,7 +13,7 @@ root = pwd
 Rake.application.options.rakelib = ["#{root}/rakelib"]
 
 desc 'Compiles chaos'
-task :default => [:create_ramdisk_image] + FOLDERS
+task default: [:create_ramdisk_image] + FOLDERS
 
 desc 'Performs cleanup (removes old .o files and similar)'
 task :clean do
@@ -27,7 +28,7 @@ task :create_ramdisk_image do
 end
 
 desc 'Compiles and installs chaos'
-task :install => [:install_folders, :iso_image]
+task install: [:install_folders, :iso_image]
 
 task :install_folders do
   FileUtils.rm_rf INSTALL_ROOT
@@ -63,16 +64,16 @@ task :storm do |folder|
 end
 
 desc "Compiles the unit tests for the 'storm' kernel."
-task :build_storm_tests => :storm do
+task build_storm_tests: :storm do
   sh "cd storm_tests && #{RAKE_COMMAND}"
 end
 
 desc 'Runs the unit tests'
-task :tests => [:build_storm_tests] do
+task tests: [:build_storm_tests] do
   sh "cd storm_tests && #{RAKE_COMMAND} tests"
 end
 
-task :libraries => [:storm] do |folder|
+task libraries: [:storm] do |folder|
   sh "cd #{folder} && #{RAKE_COMMAND}"
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Vagrant.configure(2) do |config|
   config.vm.box = 'remram/debian-9-i386'
 

--- a/libraries/Rakefile
+++ b/libraries/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 libraries = %w(
@@ -30,15 +31,15 @@ load 'constants.rake'
 INCLUDES = %w(
   -I.
   -I../storm/include
-)
+).freeze
 
-task :default => libraries + [ :startup ] do |t|
+task default: libraries + [:startup] do
   libraries.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
 end
 
-task :startup => [ :banner, 'startup.o' ] do
+task startup: [:banner, 'startup.o'] do
   puts
   puts # TODO: Should only get run sometimes...
 end
@@ -60,7 +61,7 @@ task :clean do
   rm_f Dir['*.a']
 end
 
-task :install => :default do
+task install: :default do
   libraries.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"
   end

--- a/libraries/console/Rakefile
+++ b/libraries/console/Rakefile
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   console.o
-)
+).freeze
 
-OUTPUT = 'libconsole.a'
+OUTPUT = 'libconsole.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/constants.rake
+++ b/libraries/constants.rake
@@ -1,12 +1,13 @@
-DEFINES = (ENV['DEFINES'] || '') + " -DPACKAGE=\\\"storm\\\" -DVERSION=\\\"git\\\""
+# frozen_string_literal: true
+DEFINES = (ENV['DEFINES'] || '') + ' -DPACKAGE=\\"storm\\" -DVERSION=\\"git\\"'
 
 COMMON_CFLAGS =
-"-Wall -Wextra -Wshadow -Wpointer-arith -Waggregate-return -Wredundant-decls \
--Winline -Werror -Wcast-align -Wsign-compare -Wmissing-declarations \
--Wmissing-noreturn -pipe -O3 -fno-builtin -funsigned-char \
--g -m32 -fomit-frame-pointer -ffreestanding #{ENV['EXTRA_CFLAGS']} #{DEFINES} "
+  "-Wall -Wextra -Wshadow -Wpointer-arith -Waggregate-return -Wredundant-decls \
+  -Winline -Werror -Wcast-align -Wsign-compare -Wmissing-declarations \
+  -Wmissing-noreturn -pipe -O3 -fno-builtin -funsigned-char \
+  -g -m32 -fomit-frame-pointer -ffreestanding #{ENV['EXTRA_CFLAGS']} #{DEFINES} ".freeze
 
-CFLAGS = COMMON_CFLAGS + 
-"--std=gnu99 -Wbad-function-cast -Wmissing-prototypes -Wnested-externs \
--Wstrict-prototypes"
-CCFLAGS = COMMON_CFLAGS + "--std=gnu++11 " #-Wno-c++0x-compat"
+CFLAGS = COMMON_CFLAGS +
+  "--std=gnu99 -Wbad-function-cast -Wmissing-prototypes -Wnested-externs \
+  -Wstrict-prototypes"
+CCFLAGS = COMMON_CFLAGS + '--std=gnu++11 ' #-Wno-c++0x-compat"

--- a/libraries/execute_elf/Rakefile
+++ b/libraries/execute_elf/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   execute_elf.o
-)
+).freeze
 
-OUTPUT = 'libexecute_elf.a'
+OUTPUT = 'libexecute_elf.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/file/Rakefile
+++ b/libraries/file/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   file.o
-)
+).freeze
 
-OUTPUT = 'libfile.a'
+OUTPUT = 'libfile.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/ipc/Rakefile
+++ b/libraries/ipc/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   ipc.o
-)
+).freeze
 
-OUTPUT = 'libipc.a'
+OUTPUT = 'libipc.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/ipv4/Rakefile
+++ b/libraries/ipv4/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   ipv4.o
-)
+).freeze
 
-OUTPUT = 'libipv4.a'
+OUTPUT = 'libipv4.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/libraries.rake
+++ b/libraries/libraries.rake
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 # Common settings and Rake rules for all libraries.
 
 Rake.application.options.rakelib = ["#{File.dirname(__FILE__)}/../rakelib"] if Rake.application.options.rakelib.first == 'rakelib'
 
 load "#{File.dirname(__FILE__)}/constants.rake"
 
-task :default => [ :banner, OUTPUT ] do
+task default: [:banner, OUTPUT] do
   puts
 end
 
@@ -21,7 +22,8 @@ file OUTPUT => OBJECTS do |t|
   puts
   puts '    Creating archive...'.blue.bold
 
-  # Redirecting stderr is incredibly ugly, but the problem is that I haven't found any other way to silence the default output from ar...
+  # Redirecting stderr is incredibly ugly, but the problem is that I haven't found any other way to silence the default output
+  # from ar...
   sh "#{AR} r --target=elf32-i386 #{t.name} #{t.prerequisites.join ' '} 2> /dev/null"
 
   cp t.name, '..'

--- a/libraries/list/Rakefile
+++ b/libraries/list/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   list.o
-)
+).freeze
 
-OUTPUT = 'liblist.a'
+OUTPUT = 'liblist.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/log/Rakefile
+++ b/libraries/log/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   log.o
-)
+).freeze
 
-OUTPUT = 'liblog.a'
+OUTPUT = 'liblog.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/memory/Rakefile
+++ b/libraries/memory/Rakefile
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   memory.o
   slab.o
-)
+).freeze
 
-OUTPUT = 'libmemory.a'
+OUTPUT = 'libmemory.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/pci/Rakefile
+++ b/libraries/pci/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   pci.o
-)
+).freeze
 
-OUTPUT = 'libpci.a'
+OUTPUT = 'libpci.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/random/Rakefile
+++ b/libraries/random/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   random.o
-)
+).freeze
 
-OUTPUT = 'librandom.a'
+OUTPUT = 'librandom.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/string/Rakefile
+++ b/libraries/string/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   string.o
-)
+).freeze
 
-OUTPUT = 'libstring.a'
+OUTPUT = 'libstring.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/system/Rakefile
+++ b/libraries/system/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   system.o
-)
+).freeze
 
-OUTPUT = 'libsystem.a'
+OUTPUT = 'libsystem.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/time/Rakefile
+++ b/libraries/time/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   time.o
-)
+).freeze
 
-OUTPUT = 'libtime.a'
+OUTPUT = 'libtime.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/unicode/Rakefile
+++ b/libraries/unicode/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   unicode.o
-)
+).freeze
 
-OUTPUT = 'libunicode.a'
+OUTPUT = 'libunicode.a'.freeze
 
 load '../libraries.rake'

--- a/libraries/video/Rakefile
+++ b/libraries/video/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 INCLUDES = %w(
   -I../../storm/include
   -I..
-)
+).freeze
 
 OBJECTS = %w(
   video.o
-)
+).freeze
 
-OUTPUT = 'libvideo.a'
+OUTPUT = 'libvideo.a'.freeze
 
 load '../libraries.rake'

--- a/programs/Rakefile
+++ b/programs/Rakefile
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 SUBFOLDERS = %w(
   cluido
-)
+).freeze
 
-task :default => SUBFOLDERS do |t|
+task default: SUBFOLDERS do |t|
   t.prerequisites.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
@@ -16,9 +17,9 @@ task :clean do
   end
 end
 
-task :install => :default do
+task install: :default do
   # Disabled for now, since the code that generates the folder structure isn't here yet.
-  #sh 'mcopy -o startup u:/config/servers/boot'
+  # sh 'mcopy -o startup u:/config/servers/boot'
 
   SUBFOLDERS.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"

--- a/programs/cluido/Rakefile
+++ b/programs/cluido/Rakefile
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   cluido.o
   command.o
   init.o
   nibbles.o
-)
+).freeze
 
 LIBRARIES = %w(
   console
@@ -18,8 +19,8 @@ LIBRARIES = %w(
   system
   time
   unicode
-)
+).freeze
 
-OUTPUT = 'cluido'
+OUTPUT = 'cluido'.freeze
 
 load '../programs.rake'

--- a/programs/programs.rake
+++ b/programs/programs.rake
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 # Common settings and Rake rules for all servers.
 
 Rake.application.options.rakelib = ["#{File.dirname(__FILE__)}/../rakelib"] if Rake.application.options.rakelib.first == 'rakelib'
 
-LIBRARIES_DIR = "#{File.dirname(__FILE__)}/../libraries"
+LIBRARIES_DIR = "#{File.dirname(__FILE__)}/../libraries".freeze
 
 COMMON_CFLAGS = %w(
   -Waggregate-return
@@ -27,9 +28,10 @@ COMMON_CFLAGS = %w(
   -m32
   -fomit-frame-pointer
   -ffreestanding
- )
+).freeze
 
-# TODO: Consider changing the rules in common_rules to presume that these are actually arrays. That requires us to modify all Rakefiles though.
+# TODO: Consider changing the rules in common_rules to presume that these are actually arrays. That requires us to modify all
+# Rakefiles though.
 CFLAGS = (COMMON_CFLAGS + %w(
   --std=gnu99
   -Wbad-function-cast
@@ -45,7 +47,7 @@ LDFLAGS = %W(
   -Wl,-T,#{LIBRARIES_DIR}/chaos.ld
   -m32
   -L#{LIBRARIES_DIR}
-)
+).freeze
 
 LIBRARY_FILES = LIBRARIES.map { |l| "#{LIBRARIES_DIR}/lib#{l}.a" }
 
@@ -54,18 +56,18 @@ servers_dir = File.dirname(__FILE__)
 INCLUDES = %W(
   -I#{servers_dir}/../storm/include
   -I#{servers_dir}/../libraries
-)
+).freeze
 
-task :default => [ :banner, OUTPUT ] do
+task default: [:banner, OUTPUT] do
   puts
 end
 
 task :banner do
-  print "Compiling ".bold
+  print 'Compiling '.bold
   print OUTPUT.sub('.a', '').cyan.bold
-  puts "..."
+  puts '...'
 
-  print "    "
+  print '    '
 end
 
 file OUTPUT => OBJECTS + LIBRARY_FILES do |t|
@@ -86,7 +88,7 @@ task :clean do
   rm_f OUTPUT
 end
 
-task :install => OUTPUT do
+task install: OUTPUT do
   target_path = INSTALL_ROOT + '/programs'
 
   sh "#{INSTALL_COMMAND} #{OUTPUT} #{target_path}/#{OUTPUT}"

--- a/rakelib/colorization.rake
+++ b/rakelib/colorization.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class String
   def colorize(color_code)
     "\e[#{color_code}m#{self}\e[0m"
@@ -22,7 +23,7 @@ class String
   def blue
     colorize 34
   end
-  
+
   def pink
     colorize 35
   end

--- a/rakelib/common_rules.rake
+++ b/rakelib/common_rules.rake
@@ -1,4 +1,5 @@
-rule '.o' => [ '.c' ] do |t|
+# frozen_string_literal: true
+rule '.o' => ['.c'] do |t|
   begin
     print((t.source + ' ').cyan)
     command = "#{CC} -o #{t.name} #{cflags} #{INCLUDES.join(' ')} -c #{t.source}"
@@ -9,7 +10,7 @@ rule '.o' => [ '.c' ] do |t|
   end
 end
 
-rule '.o' => [ '.rs' ] do |t|
+rule '.o' => ['.rs'] do |t|
   begin
     print((t.source + ' ').cyan)
     command = "#{RUSTC} #{RUSTCFLAGS} --crate-type lib -o #{t.name} --emit obj #{t.source}"

--- a/rakelib/common_settings.rake
+++ b/rakelib/common_settings.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 verbose false
 
 UNAME = `uname`.strip
@@ -8,14 +9,14 @@ when 'Darwin' then
 else
   CC = ENV['CC'] || 'gcc-5'
   AR = ENV['AR'] || 'ar'
-  RUSTC = 'rustc'
-  RUSTCFLAGS = '-O -C code-model=kernel -C relocation-model=static'
+  RUSTC = 'rustc'.freeze
+  RUSTCFLAGS = '-O -C code-model=kernel -C relocation-model=static'.freeze
 end
 
 # Can always use plain nasm, since even the OSX version can produce ELF images.
-NASM = 'nasm'
+NASM = 'nasm'.freeze
 
-TARGET_ARCH = 'ia32'
-RAKE_COMMAND = "rake -s -N -R #{Rake.application.options.rakelib.first}"
-INSTALL_ROOT = '/tmp/chaos-iso-build'
-INSTALL_COMMAND = 'install -D'
+TARGET_ARCH = 'ia32'.freeze
+RAKE_COMMAND = "rake -s -N -R #{Rake.application.options.rakelib.first}".freeze
+INSTALL_ROOT = '/tmp/chaos-iso-build'.freeze
+INSTALL_COMMAND = 'install -D'.freeze

--- a/rakelib/storm_settings.rake
+++ b/rakelib/storm_settings.rake
@@ -1,1 +1,2 @@
-STORM_GENERIC_LIB = 'libstorm_generic.a'
+# frozen_string_literal: true
+STORM_GENERIC_LIB = 'libstorm_generic.a'.freeze

--- a/servers/Rakefile
+++ b/servers/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
@@ -13,7 +14,7 @@ subfolders = %w(
 # sound
 # other
 
-task :default => subfolders do |t|
+task default: subfolders do |t|
   t.prerequisites.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
@@ -25,7 +26,7 @@ task :clean do
   end
 end
 
-task :install => :default do
+task install: :default do
   subfolders.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"
   end

--- a/servers/block/Rakefile
+++ b/servers/block/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
@@ -8,7 +9,7 @@ subfolders = %w(
 #
 # ata
 
-task :default => subfolders do |t|
+task default: subfolders do |t|
   t.prerequisites.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
@@ -20,7 +21,7 @@ task :clean do
   end
 end
 
-task :install => :default do
+task install: :default do
   subfolders.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"
   end

--- a/servers/block/initial_ramdisk/Rakefile
+++ b/servers/block/initial_ramdisk/Rakefile
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   initial_ramdisk.o
   ramdisk.o
-)
+).freeze
 
 LIBRARIES = %w(
   ipc
@@ -9,10 +10,10 @@ LIBRARIES = %w(
   memory
   string
   system
-)
+).freeze
 
-OUTPUT = 'initial_ramdisk'
-RAMDISK_IMAGE = 'ramdisk.image'
+OUTPUT = 'initial_ramdisk'.freeze
+RAMDISK_IMAGE = 'ramdisk.image'.freeze
 
 desc 'Creates the initial ramdisk image'
 task :create_ramdisk_image do
@@ -30,6 +31,5 @@ file 'ramdisk-auto.h' => ['ramdisk.rb', RAMDISK_IMAGE] do |t|
 
   sh "./ramdisk.rb #{RAMDISK_IMAGE} > ramdisk-auto.h"
 end
-
 
 load '../../servers.rake'

--- a/servers/block/initial_ramdisk/ramdisk.rb
+++ b/servers/block/initial_ramdisk/ramdisk.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 #
 # Abstract: Get the block size of the given file and print it as a C header.
 # Author: Per Lundberg <per@halleluja.nu>
@@ -6,7 +7,7 @@
 # © Copyright 1999-2000 chaos development
 # © Copyright 2015 chaos development
 
-file = ARGV[0] or fail 'You need to provide the name of the file to inspect'
+file = ARGV[0] or raise 'You need to provide the name of the file to inspect'
 
 BLOCK_SIZE = 512
 

--- a/servers/file_system/Rakefile
+++ b/servers/file_system/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
@@ -5,7 +6,7 @@ subfolders = %w(
   virtual_file_system
 )
 
-task :default => subfolders do |t|
+task default: subfolders do |t|
   t.prerequisites.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
@@ -17,7 +18,7 @@ task :clean do
   end
 end
 
-task :install => :default do
+task install: :default do
   subfolders.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"
   end

--- a/servers/file_system/fat/Rakefile
+++ b/servers/file_system/fat/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   clusters.o
   detect_fat.o
@@ -10,7 +11,7 @@ OBJECTS = %w(
   get_entry_by_name.o
   handle_connection.o
   read_long_file_name.o
-)
+).freeze
 
 LIBRARIES = %w(
   ipc
@@ -18,8 +19,8 @@ LIBRARIES = %w(
   memory
   string
   system
-)
+).freeze
 
-OUTPUT = 'fat'
+OUTPUT = 'fat'.freeze
 
 load '../../servers.rake'

--- a/servers/file_system/virtual_file_system/Rakefile
+++ b/servers/file_system/virtual_file_system/Rakefile
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   virtual_file_system.o
-)
+).freeze
 
 LIBRARIES = %w(
   ipc
@@ -8,8 +9,8 @@ LIBRARIES = %w(
   log
   string
   system
-)
+).freeze
 
-OUTPUT = 'virtual_file_system'
+OUTPUT = 'virtual_file_system'.freeze
 
 load '../../servers.rake'

--- a/servers/network/Rakefile
+++ b/servers/network/Rakefile
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
-  ipv4 
+  ipv4
   loopback
 )
 
-task :default => subfolders do |t|
+task default: subfolders do |t|
   t.prerequisites.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
@@ -17,7 +18,7 @@ task :clean do
   end
 end
 
-task :install => :default do
+task install: :default do
   subfolders.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"
   end

--- a/servers/network/ipv4/Rakefile
+++ b/servers/network/ipv4/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   arp.o
   dhcp.o
@@ -8,9 +9,9 @@ OBJECTS = %w(
   socket.o
   tcp.o
   udp.o
-)
+).freeze
 
-EXTRA_LDFLAGS = '-lgcc'
+EXTRA_LDFLAGS = '-lgcc'.freeze
 LIBRARIES = %w(
   ipc
   ipv4
@@ -21,8 +22,8 @@ LIBRARIES = %w(
   string
   system
   time
-)
+).freeze
 
-OUTPUT = 'ipv4'
+OUTPUT = 'ipv4'.freeze
 
 load '../../servers.rake'

--- a/servers/network/loopback/Rakefile
+++ b/servers/network/loopback/Rakefile
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   loopback.o
-)
+).freeze
 
 LIBRARIES = %w(
   ipc
@@ -8,8 +9,8 @@ LIBRARIES = %w(
   memory
   string
   system
-)
+).freeze
 
-OUTPUT = 'loopback'
+OUTPUT = 'loopback'.freeze
 
 load '../../servers.rake'

--- a/servers/servers.rake
+++ b/servers/servers.rake
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 # Common settings and Rake rules for all servers.
 
 Rake.application.options.rakelib = ["#{File.dirname(__FILE__)}/../rakelib"] if Rake.application.options.rakelib.first == 'rakelib'
 
-LIBRARIES_DIR = "#{File.dirname(__FILE__)}/../libraries"
+LIBRARIES_DIR = "#{File.dirname(__FILE__)}/../libraries".freeze
 
 COMMON_CFLAGS = %w(
   -Wall
@@ -25,9 +26,10 @@ COMMON_CFLAGS = %w(
   -m32
   -fomit-frame-pointer
   -ffreestanding
- )
+).freeze
 
-# TODO: Consider changing the rules in common_rules to presume that these are actually arrays. That requires us to modify all Rakefiles though.
+# TODO: Consider changing the rules in common_rules to presume that these are actually arrays. That requires us to modify all
+# Rakefiles though.
 CFLAGS = (COMMON_CFLAGS + %w(
   --std=gnu99
   -Wbad-function-cast
@@ -36,7 +38,7 @@ CFLAGS = (COMMON_CFLAGS + %w(
   -Wstrict-prototypes
 )).join(' ')
 
-EXTRA_LDFLAGS ||= ''
+EXTRA_LDFLAGS ||= ''.freeze
 LDFLAGS = %W(
   #{LIBRARIES_DIR}/startup.o
   -nostdlib
@@ -44,7 +46,7 @@ LDFLAGS = %W(
   -m32
   -L#{LIBRARIES_DIR}
   #{EXTRA_LDFLAGS}
-)
+).freeze
 
 LIBRARY_FILES = LIBRARIES.map { |l| "#{LIBRARIES_DIR}/lib#{l}.a" }
 
@@ -53,18 +55,18 @@ servers_dir = File.dirname(__FILE__)
 INCLUDES = %W(
   -I#{servers_dir}/../storm/include
   -I#{servers_dir}/../libraries
-)
+).freeze
 
-task :default => [ :banner, OUTPUT ] do
+task default: [:banner, OUTPUT] do
   puts
 end
 
 task :banner do
-  print "Compiling ".bold
+  print 'Compiling '.bold
   print OUTPUT.sub('.a', '').cyan.bold
-  puts "..."
+  puts '...'
 
-  print "    "
+  print '    '
 end
 
 file OUTPUT => OBJECTS + LIBRARY_FILES do |t|
@@ -85,7 +87,7 @@ task :clean do
   rm_f OUTPUT
 end
 
-task :install => OUTPUT do
+task install: OUTPUT do
   target_path = INSTALL_ROOT + '/servers'
 
   sh "#{INSTALL_COMMAND} #{OUTPUT} #{target_path}/#{OUTPUT}"

--- a/servers/system/Rakefile
+++ b/servers/system/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
@@ -8,7 +9,7 @@ subfolders = %w(
   pci
 )
 
-task :default => subfolders do |t|
+task default: subfolders do |t|
   t.prerequisites.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
@@ -20,7 +21,7 @@ task :clean do
   end
 end
 
-task :install => :default do
+task install: :default do
   subfolders.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"
   end

--- a/servers/system/boot/Rakefile
+++ b/servers/system/boot/Rakefile
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   boot.o
-)
+).freeze
 
 LIBRARIES = %w(
   execute_elf
@@ -10,8 +11,8 @@ LIBRARIES = %w(
   memory
   string
   system
-)
+).freeze
 
-OUTPUT = 'boot'
+OUTPUT = 'boot'.freeze
 
 load '../../servers.rake'

--- a/servers/system/console/Rakefile
+++ b/servers/system/console/Rakefile
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   connection.o
   console.o
   console_output.o
-)
+).freeze
 
 LIBRARIES = %w(
   ipc
@@ -11,8 +12,8 @@ LIBRARIES = %w(
   system
   unicode
   video
-)
+).freeze
 
-OUTPUT = 'console'
+OUTPUT = 'console'.freeze
 
 load '../../servers.rake'

--- a/servers/system/keyboard/Rakefile
+++ b/servers/system/keyboard/Rakefile
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   common.o
   controller.o
   init.o
   keyboard.o
   mouse.o
-)
+).freeze
 
 LIBRARIES = %w(
   console
@@ -13,8 +14,8 @@ LIBRARIES = %w(
   memory
   string
   system
-)
+).freeze
 
-OUTPUT = 'keyboard'
+OUTPUT = 'keyboard'.freeze
 
 load '../../servers.rake'

--- a/servers/system/log/Rakefile
+++ b/servers/system/log/Rakefile
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   log.o
-)
+).freeze
 
 LIBRARIES = %w(
   console
@@ -9,8 +10,8 @@ LIBRARIES = %w(
   memory
   string
   system
-)
+).freeze
 
-OUTPUT = 'log'
+OUTPUT = 'log'.freeze
 
 load '../../servers.rake'

--- a/servers/system/pci/Rakefile
+++ b/servers/system/pci/Rakefile
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   pci.o
   pci-id.o
-)
+).freeze
 
 LIBRARIES = %w(
   ipc
@@ -10,8 +11,8 @@ LIBRARIES = %w(
   memory
   string
   system
-)
+).freeze
 
-OUTPUT = 'pci'
+OUTPUT = 'pci'.freeze
 
 load '../../servers.rake'

--- a/servers/video/Rakefile
+++ b/servers/video/Rakefile
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
   vga
 )
 
-task :default => subfolders do |t|
+task default: subfolders do |t|
   t.prerequisites.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
@@ -16,7 +17,7 @@ task :clean do
   end
 end
 
-task :install => :default do
+task install: :default do
   subfolders.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"
   end

--- a/servers/video/vga/Rakefile
+++ b/servers/video/vga/Rakefile
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   vga.o
   vgalib.o
-)
+).freeze
 
 LIBRARIES = %w(
   console
@@ -9,8 +10,8 @@ LIBRARIES = %w(
   memory
   string
   system
-)
+).freeze
 
-OUTPUT = 'vga'
+OUTPUT = 'vga'.freeze
 
 load '../../servers.rake'

--- a/storm/Rakefile
+++ b/storm/Rakefile
@@ -1,21 +1,22 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
-task :default => [ 'current-arch', 'include/storm/current-arch' ] do
-  [ 'generic', 'current-arch' ].each do |folder|
+task default: ['current-arch', 'include/storm/current-arch'] do
+  ['generic', 'current-arch'].each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
 end
 
 task :clean do
   # Cannot use current-arch here, since it may not exist any more (if you run 'rake clean' multiple times).
-  [ 'generic', TARGET_ARCH ].each do |folder|
+  ['generic', TARGET_ARCH].each do |folder|
     sh "cd #{folder} && rake clean"
   end
 
-  rm_f [ 'current-arch', 'include/storm/' + TARGET_ARCH ]
+  rm_f ['current-arch', 'include/storm/' + TARGET_ARCH]
 end
 
-task :install => :default do
+task install: :default do
   sh "cd #{TARGET_ARCH} && #{RAKE_COMMAND} install"
 end
 

--- a/storm/generic/Rakefile
+++ b/storm/generic/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   arguments.o
   avl.o
@@ -17,21 +18,21 @@ OBJECTS = %w(
   system_call.o
   tag.o
   time.o
-)
+).freeze
 
 # TODO: Would like to use STORM_GENERIC_LIB, but for whatever reason it is not available in this context.
-OUTPUT = 'libstorm_generic.a'
+OUTPUT = 'libstorm_generic.a'.freeze
 
-task :default => [:banner, OUTPUT] do
+task default: [:banner, OUTPUT] do
   puts
 end
 
 task :banner do
-  print "Compiling ".bold
-  print "storm/generic".cyan.bold
-  puts "..."
+  print 'Compiling '.bold
+  print 'storm/generic'.cyan.bold
+  puts '...'
 
-  print "    "
+  print '    '
 end
 
 load '../storm.rake'

--- a/storm/ia32/Rakefile
+++ b/storm/ia32/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   cluster.o
   cpuid.o
@@ -30,17 +31,17 @@ OBJECTS = %w(
   wrapper.o
   compiler_rt/udivdi3.o
   compiler_rt/umoddi3.o
-)
+).freeze
 
-OUTPUT = 'libstorm_ia32.a'
+OUTPUT = 'libstorm_ia32.a'.freeze
 
 # TODO: Would like to use STORM_GENERIC_LIB, but for whatever reason it is not available in this context.
-GENERIC_OUTPUT = '../generic/libstorm_generic.a'
+GENERIC_OUTPUT = '../generic/libstorm_generic.a'.freeze
 
-KERNEL_OUTPUT = 'storm'
-LDFLAGS = '-nostdlib -Wl,-T,kernel.ld -m32'
+KERNEL_OUTPUT = 'storm'.freeze
+LDFLAGS = '-nostdlib -Wl,-T,kernel.ld -m32'.freeze
 
-task :default => [:banner, :prepare, :storm] + OBJECTS
+task default: [:banner, :prepare, :storm] + OBJECTS
 
 task :banner do
   print 'Compiling '.bold
@@ -55,7 +56,7 @@ task :install do
   puts "    Installed #{KERNEL_OUTPUT} in #{INSTALL_ROOT}".gray
 end
 
-task :prepare => ['wrapper.c', 'system_calls-auto.c']
+task prepare: ['wrapper.c', 'system_calls-auto.c']
 
 # TODO: I guess the header files should be listed here also.
 file 'wrapper.c' => 'system_calls.rb' do |t|

--- a/storm/storm.rake
+++ b/storm/storm.rake
@@ -1,20 +1,24 @@
-DEFINES = (ENV['DEFINES'] || '') + " -DPACKAGE_NAME=\\\"storm\\\" -DPACKAGE_VERSION=\\\"0.5.1+\\\" -DREVISION=\\\"`git rev-list HEAD --max-count 1 --abbrev-commit`\\\" -DCREATOR=\\\"`whoami`@`hostname -s`\\\""
+# frozen_string_literal: true
+
+DEFINES = (ENV['DEFINES'] || '') +
+  ' -DPACKAGE_NAME=\\"storm\\" -DPACKAGE_VERSION=\\"0.5.1+\\" -DREVISION=\\"`git rev-list HEAD --max-count 1 --abbrev-commit`\\" \
+  -DCREATOR=\\"`whoami`@`hostname -s`\\"'
 
 COMMON_CFLAGS =
-"-Wall -Wextra -Wshadow -Wpointer-arith -Waggregate-return -Wredundant-decls \
--Winline -Werror -Wcast-align -Wsign-compare -Wmissing-declarations \
--Wmissing-noreturn -pipe -O3 -fno-builtin -fno-asynchronous-unwind-tables -funsigned-char \
--g -m32 -fomit-frame-pointer -ffreestanding #{ENV['EXTRA_CFLAGS']} #{DEFINES} "
+  "-Wall -Wextra -Wshadow -Wpointer-arith -Waggregate-return -Wredundant-decls \
+  -Winline -Werror -Wcast-align -Wsign-compare -Wmissing-declarations \
+  -Wmissing-noreturn -pipe -O3 -fno-builtin -fno-asynchronous-unwind-tables -funsigned-char \
+  -g -m32 -fomit-frame-pointer -ffreestanding #{ENV['EXTRA_CFLAGS']} #{DEFINES} ".freeze
 
-CFLAGS = COMMON_CFLAGS + 
-"--std=gnu99 -Wbad-function-cast -Wmissing-prototypes -Wnested-externs \
--Wstrict-prototypes"
+CFLAGS = COMMON_CFLAGS +
+  "--std=gnu99 -Wbad-function-cast -Wmissing-prototypes -Wnested-externs \
+  -Wstrict-prototypes"
 
 INCLUDES = %w(
   -I../include
   -I..
   -I.
-)
+).freeze
 
 file OUTPUT => OBJECTS do |t|
   puts

--- a/storm_tests/Rakefile
+++ b/storm_tests/Rakefile
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w(
-  ia32 
+  ia32
 )
 
-task :default => subfolders do |t|
+task default: subfolders do |t|
   t.prerequisites.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND}"
   end
@@ -16,7 +17,7 @@ task :clean do
   end
 end
 
-task :build_tests => :default do
+task build_tests: :default do
   subfolders.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} build_tests"
   end

--- a/storm_tests/ia32/Rakefile
+++ b/storm_tests/ia32/Rakefile
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 OBJECTS = %w(
   ia32_tests_main.o
   memory_global_test.o
   string_tests.o
-)
+).freeze
 
 OUTPUT = :ia32_tests
 
@@ -11,18 +12,18 @@ LDFLAGS = %w(
   -L/usr/local/lib
   -L../../storm/generic
   -L../../storm/ia32
-)
+).freeze
 
-  # Need to provide the same name twice for linking to succeed. (circular dependency?)
+# Need to provide the same name twice for linking to succeed. (circular dependency?)
 LIBRARIES = %w(
   cmocka
 
   storm_ia32
   storm_generic
   storm_ia32
-)
+).freeze
 
-task :default => [ :banner, OUTPUT ]
+task default: [:banner, OUTPUT]
 
 task :banner do
   print 'Compiling '.bold

--- a/storm_tests/storm_tests.rake
+++ b/storm_tests/storm_tests.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rake.application.options.rakelib = ["#{File.dirname(__FILE__)}/../rakelib"] if Rake.application.options.rakelib.first == 'rakelib'
 
 # FIXME: Don't repeat all of these in many places.
@@ -19,7 +20,7 @@ COMMON_CFLAGS = %w(
   -funsigned-char
   -m32
   -fomit-frame-pointer
-)
+).freeze
 
 CFLAGS = COMMON_CFLAGS + %w(
   --std=gnu99
@@ -30,10 +31,10 @@ CFLAGS = COMMON_CFLAGS + %w(
   -Wstrict-prototypes
 )
 
-INCLUDES = %W(
+INCLUDES = %w(
   -I..
   -I../../storm/include
-)
+).freeze
 
 def run_test(test)
   sh "./#{test} 2>&1 | #{Rake.application.options.rakelib.first}/../tools/colorize.rb"

--- a/tools/colorize.rb
+++ b/tools/colorize.rb
@@ -1,6 +1,10 @@
 #!/usr/bin/ruby
+# frozen_string_literal: true
+# rubocop:disable Semicolon
 
-$return_value = 0
+require 'English'
+
+@return_value = 0
 
 def colorize(s, color_code)
   "\e[#{color_code}m#{s}\e[0m"
@@ -17,16 +21,16 @@ end
 line_count = 0
 
 while gets
-  line_count = line_count + 1
-  $_.gsub!(/ OK /) { |s| green s }
-  $_.gsub!(/  PASSED/) { |s| green s }
-  $_.gsub!(/  FAILED/) { |s| $return_value = 1; red s; }
-  $_.gsub!(/\d+ FAILED.*/) { |s| $return_value = 1; red s; }
+  line_count += 1
+  $LAST_READ_LINE.gsub!(/ OK /) { |s| green s }
+  $LAST_READ_LINE.gsub!(/  PASSED/) { |s| green s }
+  $LAST_READ_LINE.gsub!(/  FAILED/) { |s| @return_value = 1; red s; }
+  $LAST_READ_LINE.gsub!(/\d+ FAILED.*/) { |s| @return_value = 1; red s; }
 
-  puts $_
+  puts $LAST_READ_LINE
 end
 
 # No lines received = something went wrong with the test running.
 exit 1 if line_count == 0
 
-exit $return_value
+exit @return_value


### PR DESCRIPTION
Background: when I started setting up the tooling for compiling chaos with Rake (instead of `autochaos`, our own home-made Perl-based build tool), I wasn't as experienced with Ruby as I am today. I didn't use Rubocop. I didn't follow [the Ruby style guide](https://github.com/bbatsov/ruby-style-guide). Hence, the code followed what I believed _then_ to be a reasonable form, in terms of formatting.

Nowadays, I am using Rubocop a lot at work so it feels natural to use it for the FOSS stuff as well. This PR makes the code be linting clean. Also, it runs Rubocop on each build, to ensure that we _stay_ clean.