### PR TITLE
Fixed the dispatcher yield CPU when no thread is currently active (decreases CPU usage)

### DIFF
--- a/storm/generic/idle.c
+++ b/storm/generic/idle.c
@@ -1,7 +1,7 @@
 // Abstract: Idle thread.
 // Author: Per Lundberg <per@halleluja.nu>
 
-// © Copyright 2000, 2013 chaos development.
+// © Copyright 2000, 2013, 2016 chaos development.
 
 #include <storm/generic/debug.h>
 #include <storm/generic/idle.h>
@@ -17,7 +17,6 @@ void idle (void)
   {
     // FIXME: If we get here, the system is totaly asleep, and we can safely check for tasks to do. For now, only try to find a
     // thread to run.
-    // TODO: Perform ACPI sleeping to reduce CPU usage and hence battery usgae.
     dispatch_next ();
   }
 }

--- a/storm/ia32/dispatch.c
+++ b/storm/ia32/dispatch.c
@@ -5,7 +5,7 @@
 // © Copyright 1999-2000 chaos development
 // © Copyright 2007 chaos development
 // © Copyright 2013 chaos development
-// © Copyright 2015 chaos development
+// © Copyright 2015-2016 chaos development
 
 // Define this as TRUE if you want *lots* of debug information.
 #define DEBUG FALSE
@@ -204,13 +204,16 @@ void dispatch_next(void)
         // There is at least one more task that should be executed, so let's do it.
         mutex_kernel_signal(&tss_tree_mutex);
         dispatch();
+        cpu_interrupts_enable();
     }
     else
     {
+        // No other thread to run. We need to make _sure_ to yield the CPU in this case; otherwise we will always consume 100%
+        // CPU, even when we are completely idle.
         mutex_kernel_signal(&tss_tree_mutex);
+        cpu_interrupts_enable();
+        asm("hlt");
     }
-
-    cpu_interrupts_enable();
 }
 
 // Update dispatcher information. Called from the IRQ 0 handler.


### PR DESCRIPTION
This has a very significant impact on CPU usage, and inherently also battery usage (on laptops). Since 100% of the actual running of chaos these days is in a VM, it feels especially important and relevant.

Closes #57.