### PR TITLE
Disable the Rust toolchain for now

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,9 +20,10 @@ Vagrant.configure(2) do |config|
       qemu \
       rake
 
-    # We need the beta channel for the #![feature] functionality.
-    curl -sSf https://static.rust-lang.org/rustup.sh > /tmp/rustup.sh && \
-      sh /tmp/rustup.sh --yes --channel=nightly --date=2016-01-13
+    # Disabled for now since we don't have any Rust dependencies, and 
+    ## We need the beta channel for the #![feature] functionality.
+    #curl -sSf https://static.rust-lang.org/rustup.sh > /tmp/rustup.sh && \
+    #  sh /tmp/rustup.sh --yes --channel=nightly --date=2016-01-13
 
     cd /vagrant
     ./install_cmocka.sh


### PR DESCRIPTION
We don't really _depend_ on it, since #59 is far from being mergable. Let's disable it for now since it just slows things down.