### PR TITLE
Travis: Support newer gcc versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,80 @@
 sudo: required
 dist: trusty
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - gcc-4.9-multilib
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && ARCH=x86"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - gcc-5-multilib
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && ARCH=x86"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - gcc-6-multilib
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && ARCH=x86"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+            - gcc-7-multilib
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && ARCH=x86"
+
+    - os: linux
+      addons:
+        apt:
+          packages:
+            - gcc-arm-none-eabi
+      env:
+        - MATRIX_EVAL="ARCH=raspberrypi"
+
+addons:
+  apt:
+    packages:
+
+before_install:
+ - eval "${MATRIX_EVAL}"
+ - export CC
+ - export ARCH
+
 before_script:
  - sudo apt-get update
  - sudo apt-get install
      dosfstools
-     gcc-arm-none-eabi
-     gcc-multilib
      genisoimage
      grub
      mtools
      nasm
  - ./install_cmocka.sh
+
+# Tests are disabled for now since cmocka don't work on Trusty Tahr.
 script:
  - bundle exec rubocop
- - ARCH=raspberrypi rake
-     default
-     clean
- # Tests are disabled for now since cmocka don't work on Trusty Tahr.
- - ARCH=x86 CC=gcc rake
-     default
+ - rake default

--- a/libraries/string/string.c
+++ b/libraries/string/string.c
@@ -538,6 +538,10 @@ return_type string_print_va(char *output, const char *format_string,
                     case 'X':
                     {
                         flags |= UPPER_HEX;
+
+                        // Falls through by design. (Can't use __attribute__ ((fallthrough)), since it breaks on gcc < 7.)
+                        //
+                        /* @fallthrough@ */
                     }
 
                     case 'x':

--- a/libraries/string/string.c
+++ b/libraries/string/string.c
@@ -539,10 +539,9 @@ return_type string_print_va(char *output, const char *format_string,
                     {
                         flags |= UPPER_HEX;
 
-                        // Falls through by design. (Can't use __attribute__ ((fallthrough)), since it breaks on gcc < 7.)
-                        //
-                        /* @fallthrough@ */
                     }
+                    // Falls through by design. (Can't use __attribute__ ((fallthrough)), since it breaks on gcc < 7.)
+                    // @fallthrough@
 
                     case 'x':
                     {

--- a/libraries/string/string.c
+++ b/libraries/string/string.c
@@ -542,7 +542,7 @@ return_type string_print_va(char *output, const char *format_string,
                     }
                     // Falls through by design. (Can't use __attribute__ ((fallthrough)), since it breaks on gcc < 7.)
                     //
-                    // @fallthrough@
+                    // fallthrough
                     case 'x':
                     {
                         char string[9];

--- a/libraries/string/string.c
+++ b/libraries/string/string.c
@@ -541,8 +541,8 @@ return_type string_print_va(char *output, const char *format_string,
 
                     }
                     // Falls through by design. (Can't use __attribute__ ((fallthrough)), since it breaks on gcc < 7.)
+                    //
                     // @fallthrough@
-
                     case 'x':
                     {
                         char string[9];

--- a/rakelib/common_rules.rake
+++ b/rakelib/common_rules.rake
@@ -24,7 +24,7 @@ end
 rule '.o' => ['.S'] do |t|
   begin
     print((t.source + ' ').cyan)
-    command = "#{CC} -o #{t.name} #{CFLAGS} #{INCLUDES.join(' ')} -c #{t.source}"
+    command = "#{CC} -o #{t.name} #{cflags} #{INCLUDES.join(' ')} -c #{t.source}"
     sh command
   rescue
     puts "Error compiling #{t.source}. Full command line was: #{command}"
@@ -44,6 +44,11 @@ rule '.o' => ['.asm'] do |t|
 end
 
 def cflags
-  flags = CFLAGS.join(' ') if CFLAGS.respond_to?(:join)
-  flags || CFLAGS
+  flags = if CFLAGS.respond_to?(:join)
+    CFLAGS.join(' ')
+  else
+      CFLAGS
+  end
+
+  flags + ' ' + ARCH_CFLAGS
 end

--- a/rakelib/common_settings.rake
+++ b/rakelib/common_settings.rake
@@ -28,7 +28,10 @@ else
     AR = ENV['AR'] || 'ar'
     AR_TARGET = '--target=elf32-i386'.freeze
     NASM = 'nasm'.freeze
-    ARCH_CFLAGS = '-m32'.freeze
+
+    extra_cflags = '-m32'
+    extra_cflags += ' -Wimplicit-fallthrough=4' if CC =~ /gcc-7/
+    ARCH_CFLAGS = extra_cflags.freeze
   elsif TARGET_ARCH == 'raspberrypi'
     CC = ENV['CC'] || 'arm-none-eabi-gcc'
     AR = ENV['AR'] || 'arm-none-eabi-ar'

--- a/rakelib/common_settings.rake
+++ b/rakelib/common_settings.rake
@@ -30,7 +30,7 @@ else
     NASM = 'nasm'.freeze
 
     extra_cflags = '-m32'
-    extra_cflags += ' -Wimplicit-fallthrough=3' if CC =~ /gcc-7/
+    extra_cflags += ' -Werror=implicit-fallthrough=3' if CC =~ /gcc-7/
     ARCH_CFLAGS = extra_cflags.freeze
   elsif TARGET_ARCH == 'raspberrypi'
     CC = ENV['CC'] || 'arm-none-eabi-gcc'

--- a/rakelib/common_settings.rake
+++ b/rakelib/common_settings.rake
@@ -28,10 +28,7 @@ else
     AR = ENV['AR'] || 'ar'
     AR_TARGET = '--target=elf32-i386'.freeze
     NASM = 'nasm'.freeze
-
-    extra_cflags = '-m32'
-    extra_cflags += ' -Werror=implicit-fallthrough=3' if CC =~ /gcc-7/
-    ARCH_CFLAGS = extra_cflags.freeze
+    ARCH_CFLAGS = '-m32'.freeze
   elsif TARGET_ARCH == 'raspberrypi'
     CC = ENV['CC'] || 'arm-none-eabi-gcc'
     AR = ENV['AR'] || 'arm-none-eabi-ar'

--- a/rakelib/common_settings.rake
+++ b/rakelib/common_settings.rake
@@ -30,7 +30,7 @@ else
     NASM = 'nasm'.freeze
 
     extra_cflags = '-m32'
-    extra_cflags += ' -Wimplicit-fallthrough=4' if CC =~ /gcc-7/
+    extra_cflags += ' -Wimplicit-fallthrough=3' if CC =~ /gcc-7/
     ARCH_CFLAGS = extra_cflags.freeze
   elsif TARGET_ARCH == 'raspberrypi'
     CC = ENV['CC'] || 'arm-none-eabi-gcc'

--- a/storm/include/storm/generic/bit.h
+++ b/storm/include/storm/generic/bit.h
@@ -1,14 +1,16 @@
 // Abstract: Bit functions.
 // Author: Per Lundberg <per@chaosdev.io>
 
-// © Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999-2000 chaos development
+// © Copyright 2013 chaos development
+// © Copyright 2017 chaos development
 
 #pragma once
 
 #if (defined __i386__) || (defined __i486__) || (defined __i586__) || (defined __i686__)
 // Little-endian system.
 #   define BIT_SET(a, b) ((a) |= (1 << (b)))
-#   define BIT_CLEAR(a, b) ((a) &= !(1 << (b)))
+#   define BIT_CLEAR(a, b) ((a) &= ~(1 << (b)))
 #   define BIT_GET(a, b) ((a) & (1 << (b)) ? 1 : 0)
 #   define BIT_IN_BYTES(a) ((a) % 8 != 0 ? (a) / 8 + 1 : (a) / 8)
 

--- a/storm/raspberrypi/Rakefile
+++ b/storm/raspberrypi/Rakefile
@@ -13,7 +13,7 @@ OUTPUT = 'libstorm_raspberrypi.a'.freeze
 GENERIC_OUTPUT = '../generic/libstorm_generic.a'.freeze
 
 KERNEL_OUTPUT = 'storm'.freeze
-LDFLAGS = '-nostartfiles'.freeze
+LDFLAGS = '-nostdlib'.freeze
 
 task default: [:banner, :prepare, :storm] + objects
 

--- a/storm/x86/dma.c
+++ b/storm/x86/dma.c
@@ -20,20 +20,20 @@
 #define DMA_CHANNEL_CASCADE          4
 
 // Controller registers.
-static const unsigned int dma_controller[NUMBER_OF_CONTROLLERS] =
-{
-    0x08, 0xD0
-};
+// static const unsigned int dma_controller[NUMBER_OF_CONTROLLERS] =
+// {
+//     0x08, 0xD0
+// };
 
-static const unsigned int dma_master_reset[NUMBER_OF_CONTROLLERS] =
-{
-    0x0D, 0xDA
-};
+// static const unsigned int dma_master_reset[NUMBER_OF_CONTROLLERS] =
+// {
+//     0x0D, 0xDA
+// };
 
-static const unsigned int dma_master_mask[NUMBER_OF_CONTROLLERS] =
-{
-    0x0F, 0xDE
-};
+// static const unsigned int dma_master_mask[NUMBER_OF_CONTROLLERS] =
+// {
+//     0x0F, 0xDE
+// };
 
 static const unsigned int dma_mask[NUMBER_OF_CONTROLLERS] =
 {


### PR DESCRIPTION
In fact, run on both gcc 4.9, 5, 6 and 7. This is probably overkill in the long run. If it turns out to be a maintenance nightmare, we can drop one or more of these easily.

Closes #83. 🎉 