### PR TITLE
Rake: Recreate the ramdisk image on each rake install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ task :create_ramdisk_image do
 end
 
 desc 'Compiles and installs chaos'
-task install: [:install_folders, :iso_image]
+task install: [:create_ramdisk_image, :install_folders, :iso_image]
 
 task :install_folders do
   FileUtils.rm_rf INSTALL_ROOT

--- a/programs/Rakefile
+++ b/programs/Rakefile
@@ -18,8 +18,13 @@ task :clean do
 end
 
 task install: :default do
-  # Disabled for now, since the code that generates the folder structure isn't here yet.
-  # sh 'mcopy -o startup u:/config/servers/boot'
+  # The volume is always recreated on 'rake install', so the folder structure must be created from scratch.
+  sh 'mmd u:/config'
+  sh 'mmd u:/config/servers'
+  sh 'mmd u:/config/servers/boot'
+  sh 'mcopy -o startup u:/config/servers/boot'
+
+  sh 'mmd u:/programs'
 
   SUBFOLDERS.each do |folder|
     sh "cd #{folder} && #{RAKE_COMMAND} install"


### PR DESCRIPTION
Previously, it was created each time the `default` task was run. This change fixes it so that you can run `rake install` over and over again.

The programs/Rakefile file was also fixed to create the folder for the config/servers/boot/startup script.