### PR TITLE
Map process page tables using magic PD entry

### DIFF
--- a/documentation/virtual-memory.md
+++ b/documentation/virtual-memory.md
@@ -11,7 +11,7 @@ Start                       | Length        | Description
 `0x00100000`                | Varying       | Kernel code and data.
 `0x00300000`                | `0x00100000`  | Process code and data. Used by `process_create`.
 `0x00400000`                | `0x01C00000`  | Process' low-level memory allocation structures.
-`0x02000000`                | `0x00400000`  | Process' page tables.
+`0x02000000`                | `0x00400000`  | Process' page tables. Mapped using a [self-referencing page directory entry](http://wiki.osdev.org/Page_Tables#Recursive_mapping).
 `0x02400000`                | `0x00400000`  | Process data. Parameters and other info.
 `0x02800000`                | `SIZE_GLOBAL` | Global data area. Hifi-Eslöf, ports, etc...
 `0x02800000 + SIZE_GLOBAL`  | Varying       | Freely disposable by process (process data and code, process heap etc.)

--- a/storm/include/storm/generic/memory_virtual.h
+++ b/storm/include/storm/generic/memory_virtual.h
@@ -16,9 +16,11 @@
 extern void memory_virtual_init(void) INIT_CODE;
 extern void memory_virtual_enable(void) INIT_CODE;
 
-extern return_type memory_virtual_map_kernel(page_directory_entry_page_table *page_directory, uint32_t virtual_page, uint32_t physical_page,
-                                             uint32_t pages, uint32_t flags) INIT_CODE;
-extern return_type memory_virtual_map_other(storm_tss_type *tss, uint32_t virtual_page, uint32_t physical_page, uint32_t pages, uint32_t flags);
+extern return_type memory_virtual_map_paging_disabled(page_directory_entry_page_table *page_directory,
+                                                      uint32_t virtual_page, uint32_t physical_page, uint32_t pages,
+                                                      uint32_t flags) INIT_CODE;
+extern return_type memory_virtual_map_other(storm_tss_type *tss, uint32_t virtual_page, uint32_t physical_page,
+                                            uint32_t pages, uint32_t flags);
 extern return_type memory_virtual_map(uint32_t virtual_page, uint32_t physical_page, uint32_t pages, uint32_t flags) WEAK;
 extern void memory_virtual_unmap(uint32_t virtual_page, uint32_t pages);
 extern return_type map(process_id_type pid, uint32_t linear_page, uint32_t physical_page, uint32_t pages);
@@ -30,6 +32,8 @@ extern void memory_virtual_dump_map(page_directory_entry_page_table *page_direct
 extern return_type memory_virtual_allocate(uint32_t *page_number, uint32_t pages);
 extern return_type memory_virtual_deallocate(uint32_t page_number);
 extern return_type memory_virtual_reserve(unsigned int start_page, unsigned int pages);
+extern void memory_virtual_create_page_tables_mapping(page_directory_entry_page_table *process_page_directory,
+                                                      uint32_t page_directory_page);
 
 extern avl_header_type *process_avl_header;
 extern page_directory_entry_page_table *kernel_page_directory;

--- a/storm/include/storm/limits.h
+++ b/storm/include/storm/limits.h
@@ -2,17 +2,15 @@
 // Authors: Per Lundberg <per@chaosdev.io>
 //          Henrik Hallin <hal@chaosdev.org>
 //
-// © Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999 chaos development.
 
 #pragma once
 
 #include <storm/types.h>
 
 // Limits of types.
-#define MAX_U8                          ((uint8_t) - 1)
-#define MAX_U16                         ((uint16_t) - 1)
-#define MAX_uint32_t                         ((uint32_t) - 1)
-#define MAX_TIME                        ((time_type) - 1)
+#define MAX_U16                         ((uint16_t) -1)
+#define MAX_TIME                        ((time_type) -1)
 
 // Other limitations.
 #define MAX_PROCESS_NAME_LENGTH         128

--- a/storm/include/storm/x86/defines.h
+++ b/storm/include/storm/x86/defines.h
@@ -54,6 +54,9 @@
 #define BASE_PROCESS_PARAMETERS         (36 * MB)
 #define BASE_PROCESS_STACK              ((4 * GB) - SIZE_PROCESS_STACK)
 
+#define PROCESS_PAGE_TABLES_PAGE_DIRECTORY_INDEX \
+                                        (BASE_PROCESS_PAGE_TABLES / SIZE_PAGE / 1024)
+
 // Kernel virtual addresses. Only used during bootup.
 #define BASE_MODULE                     (2 * GB)
 

--- a/storm/x86/memory_physical.c
+++ b/storm/x86/memory_physical.c
@@ -181,9 +181,12 @@ return_type memory_physical_allocate(uint32_t *page, unsigned int length, const 
     avl_node_type *node = page_avl_header->root;
     avl_node_type *insert_node;
 
-    if (tss_tree_mutex != MUTEX_LOCKED && memory_mutex != MUTEX_LOCKED && initialised)
+    if (initialised)
     {
-        DEBUG_HALT("Code is not properly mutexed.");
+        if (tss_tree_mutex != MUTEX_LOCKED && memory_mutex != MUTEX_LOCKED)
+        {
+            DEBUG_HALT("tss_tree_mutex or memory_mutex is expected to be locked when this method is called, but both of these mutexes were unlocked.");
+        }
     }
 
     //debug_print ("Called for: %s\n", description);

--- a/storm/x86/thread.c
+++ b/storm/x86/thread.c
@@ -217,32 +217,28 @@ thread_id_type thread_get_free_id(void)
 // a cluster. Discuss how this is best done! Right now, we lock everything, which is sub-optimal.
 return_type thread_create(void *(*start_routine) (void *), void *argument)
 {
+
     storm_tss_type *new_tss;
-    page_directory_entry_page_table *new_page_directory = (page_directory_entry_page_table *) BASE_PROCESS_TEMPORARY;
-    page_table_entry *new_page_table = (page_table_entry *) (BASE_PROCESS_TEMPORARY + SIZE_PAGE);
-    uint32_t stack_physical_page, page_directory_physical_page, page_table_physical_page;
+    uint32_t stack_physical_page, page_directory_physical_page, system_page_table_physical_page;
     int index;
     process_info_type *process_info;
 
-    // FIXME: We shouldn't have to do like this.
-    DEBUG_MESSAGE(DEBUG, "Disabling interrupts");
     cpu_interrupts_disable();
-
-    // Add the new task to the task list, so we can map for the new thread.
     mutex_kernel_wait(&memory_mutex);
+    mutex_kernel_wait(&tss_tree_mutex);
 
     // FIXME: Check return value.
     memory_physical_allocate(&page_directory_physical_page, 1, "Thread page directory.");
-    memory_physical_allocate(&page_table_physical_page, 1, "Thread page table.");
+    memory_physical_allocate(&system_page_table_physical_page, 1, "Thread page table (system pages)");
 
     // Map the page directory and the lowest page table.
     memory_virtual_map(GET_PAGE_NUMBER(BASE_PROCESS_TEMPORARY), page_directory_physical_page, 1, PAGE_KERNEL);
-    memory_virtual_map(GET_PAGE_NUMBER(BASE_PROCESS_TEMPORARY) + 1, page_table_physical_page, 1, PAGE_KERNEL);
+    memory_virtual_map(GET_PAGE_NUMBER(BASE_PROCESS_TEMPORARY) + 1, system_page_table_physical_page, 1, PAGE_KERNEL);
+    page_directory_entry_page_table *new_page_directory = (page_directory_entry_page_table *) BASE_PROCESS_TEMPORARY;
+    page_table_entry *system_page_table = (page_table_entry *) (BASE_PROCESS_TEMPORARY + SIZE_PAGE);
 
     // Allocate memory for a TSS.
     new_tss = ((storm_tss_type *) memory_global_allocate(sizeof (storm_tss_type) + current_tss->iomap_size));
-
-    mutex_kernel_signal(&memory_mutex);
 
     // Clone the TSS.
     memory_copy((uint8_t *) new_tss, (uint8_t *) current_tss, sizeof (storm_tss_type) + current_tss->iomap_size);
@@ -250,9 +246,7 @@ return_type thread_create(void *(*start_routine) (void *), void *argument)
     // FIXME: tss_tree_mutex should be changed to a 'dispatcher_mutex', or something... This looks a little weird if
     // you don't know why it's written this way.
 
-    mutex_kernel_wait(&tss_tree_mutex);
     new_tss->thread_id = thread_get_free_id();
-    mutex_kernel_signal(&tss_tree_mutex);
 
     // What has changed in the TSS is the ESP/ESP0 and the EIP. We must update those fields.
     new_tss->eip = (uint32_t) start_routine;
@@ -260,10 +254,9 @@ return_type thread_create(void *(*start_routine) (void *), void *argument)
 
     //  debug_print ("thread: %u\n", new_tss->thread_id);
 
-    /* Clone the page directory and the lowest page table. */
-
+    // Clone the page directory and the lowest page table.
     memory_copy((uint8_t *) new_page_directory, (uint8_t *) BASE_PROCESS_PAGE_DIRECTORY, SIZE_PAGE);
-    memory_copy((uint8_t *) new_page_table, (uint8_t *) BASE_PROCESS_PAGE_TABLES, SIZE_PAGE);
+    memory_copy((uint8_t *) system_page_table, (uint8_t *) BASE_PROCESS_PAGE_TABLES, SIZE_PAGE);
 
     // Set the stack as non-present.
     // FIXME: defines.
@@ -273,31 +266,16 @@ return_type thread_create(void *(*start_routine) (void *), void *argument)
     }
 
     // Map the thread's page directory and update the mapping for the first pagetable.
-
-#if FALSE
-    new_page_directory[0].page_table_base = page_table_physical_page;
+    new_page_directory[0].page_table_base = system_page_table_physical_page;
     memory_virtual_map_other(new_tss,
                              GET_PAGE_NUMBER(BASE_PROCESS_PAGE_DIRECTORY),
                              page_directory_physical_page, 1, PAGE_KERNEL);
 
-    // The 4 MB region where the pagetables are mapped also need to be unique.
-
-    memory_physical_allocate(&page_table_physical_page, 1);
-
-    memory_virtual_map(GET_PAGE_NUMBER(BASE_PROCESS_TEMPORARY) + 1,
-                       page_table_physical_page, 1, PAGE_KERNEL);
-
-    memory_copy((uint8_t *) new_page_table, (uint8_t *) BASE_PROCESS_PAGE_TABLES, SIZE_PAGE);
-
-    new_page_directory[8].page_table_base = page_table_physical_page;
-    memory_virtual_map_other(new_tss,
-                             GET_PAGE_NUMBER(BASE_PROCESS_PAGE_TABLES),
-                             page_table_physical_page, 1, PAGE_KERNEL);
-#endif
+    // The "magical" mapping previously created by memory_virtual_create_page_tables_mapping also needs to be adjusted.
+    // Otherwise we will update the wrong thread's addressing space when mapping memory for the new thread.
+    memory_virtual_create_page_tables_mapping(new_page_directory, page_directory_physical_page);
 
     // FIXME: Map into all sister threads address spaces when creating a new page table for a thread.
-
-    mutex_kernel_wait(&memory_mutex);
 
     // Start by creating a PL0 stack. Remember that the lowest page of the stack area is the PL0 stack.
     // FIXME: Check return value.
@@ -333,23 +311,20 @@ return_type thread_create(void *(*start_routine) (void *), void *argument)
     memory_virtual_map_other(new_tss, MAX_PAGES - current_tss->stack_pages, stack_physical_page, current_tss->stack_pages,
                              PAGE_WRITABLE | PAGE_NON_PRIVILEGED);
 
-    mutex_kernel_signal(&memory_mutex);
-
     new_tss->ss = new_tss->ss0;
     new_tss->cs = SELECTOR_KERNEL_CODE;
     new_tss->eflags = THREAD_NEW_EFLAGS;
     new_tss->timeslices = 0;
     string_copy(new_tss->thread_name, "unnamed");
 
-    mutex_kernel_wait(&tss_tree_mutex);
     process_info = (process_info_type *) new_tss->process_info;
     thread_link_list(&process_info->thread_list, new_tss);
     thread_link(new_tss);
     number_of_tasks++;
     process_info->number_of_threads++;
-    mutex_kernel_signal(&tss_tree_mutex);
 
-    DEBUG_MESSAGE(DEBUG, "Enabling interrupts");
+    mutex_kernel_signal(&tss_tree_mutex);
+    mutex_kernel_signal(&memory_mutex);
     cpu_interrupts_enable();
 
     return STORM_RETURN_SUCCESS;

--- a/storm/x86/trap.c
+++ b/storm/x86/trap.c
@@ -343,12 +343,14 @@ void trap_init(void)
     trap_stack = (void *) (physical_page * SIZE_PAGE);
 
     // Map this.
-    memory_virtual_map_kernel
-        (kernel_page_directory, GET_PAGE_NUMBER(BASE_PROCESS_TRAP_TSS),
-        GET_PAGE_NUMBER(trap_tss), 1, PAGE_KERNEL);
-    memory_virtual_map_kernel
-        (kernel_page_directory, GET_PAGE_NUMBER(BASE_TRAP_STACK),
-        GET_PAGE_NUMBER(trap_stack), 1, PAGE_KERNEL);
+    memory_virtual_map_paging_disabled(
+        kernel_page_directory, GET_PAGE_NUMBER(BASE_PROCESS_TRAP_TSS),
+        GET_PAGE_NUMBER(trap_tss), 1, PAGE_KERNEL
+    );
+    memory_virtual_map_paging_disabled(
+        kernel_page_directory, GET_PAGE_NUMBER(BASE_TRAP_STACK),
+        GET_PAGE_NUMBER(trap_stack), 1, PAGE_KERNEL
+    );
 
     // Wipe the TSS.
     memory_set_uint8_t((uint8_t *) trap_tss, 0, SIZE_PAGE);


### PR DESCRIPTION
This is a clever hack, inspired by OSDev: http://wiki.osdev.org/Page_Tables#Recursive_mapping (I also saw it on some other page there, but can't remember its location right now.)

It simplifies our code, since it means we never have to  update any particular page table mapping when creating a new page table for a thread or process. When we add the page table into the page directory, we _automatically_ can access the page table itself at a deterministic location, which is really convenient.

(Identity mapping all physical memory to virtual address 0 - 2 GiB would have been an even better approach, but it's a much more significant change that involves _a lot_ of `#defines` to be changed, and I'm not willing to spend all that work right now. Besides, you could use this approach even with identity mapping since it will mean that each thread will always have its page table zone at the same virtual location, which again, makes the code easier to write and maintain...)

I have tested booting up the system with this change in place, and it seems to work fine for me; cluido boots etc.