### PR TITLE
(ci) Support gcc-8, remove gcc-6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,7 @@ dist: xenial
 
 matrix:
   include:
-    # Default version in Debian stable (stretch)
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-6
-            - gcc-6-multilib
-      env:
-        - MATRIX_EVAL="CC=gcc-6 && ARCH=x86"
-
-    # Available, but not default, in Debian testing (buster)
+    # Old version available in Debian buster
     - os: linux
       addons:
         apt:
@@ -26,6 +14,18 @@ matrix:
             - gcc-7-multilib
       env:
         - MATRIX_EVAL="CC=gcc-7 && ARCH=x86"
+
+    # Default in Debian buster
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+            - gcc-8-multilib
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && ARCH=x86"
 
     # Highly experimental Raspberry Pi port
     - os: linux

--- a/servers/network/ipv4/ipv4.c
+++ b/servers/network/ipv4/ipv4.c
@@ -440,7 +440,7 @@ static void handle_connection(mailbox_id_type *reply_mailbox_id)
 }
 
 // Handle the connection to the ethernet service.
-static bool handle_ethernet(mailbox_id_type *mailbox_id)
+static void handle_ethernet(mailbox_id_type *mailbox_id)
 {
     ipc_structure_type *ethernet_structure;
     ipc_structure_type **ethernet_structure_pointer = &ethernet_structure;
@@ -466,7 +466,7 @@ static bool handle_ethernet(mailbox_id_type *mailbox_id)
     if (ipc_service_connection_request(ethernet_structure) != IPC_RETURN_SUCCESS)
     {
         log_print(&log_structure, LOG_URGENCY_EMERGENCY, "Couldn't connect to ethernet service.");
-        return FALSE;
+        return;
     }
 
     // Read the ethernet hardware address.
@@ -567,8 +567,6 @@ static bool handle_ethernet(mailbox_id_type *mailbox_id)
             }
         }
     }
-
-    return TRUE;
 }
 
 // Main function

--- a/servers/servers.rake
+++ b/servers/servers.rake
@@ -19,6 +19,7 @@ COMMON_CFLAGS = %W[
   -Winline
   -Werror
   -Wcast-align
+  -Wno-cast-function-type
   -Wno-pointer-sign
   -Wsign-compare
   -Wmissing-declarations


### PR DESCRIPTION
I noted while setting up a local Debian development environment that Debian testing (`buster`) is now on gcc 8. ~4.9 and 5 are really old by now, we can drop support for them entirely and add support for gcc 8 instead.~ 4.9 and 5 already gone by now. This PR was changed to remove gcc-6 instead.
