### PR TITLE
Fix thread_create to use PL3 stack instead of PL0

### DIFF
--- a/libraries/system/system_calls.h
+++ b/libraries/system/system_calls.h
@@ -223,6 +223,7 @@ static inline return_type system_call_thread_create(thread_entry_point_type *thr
 
     asm volatile("pushl %1\n"
                  "pushl %2\n"
+                 "pushl %%esp\n" // Need to be last (i.e. first) because %1 and %2 will be %esp-relative references.
                  "lcall %3, $0"
                  : "=a" (return_value)
                  : "ri" (argument),

--- a/storm/generic/system_call.c
+++ b/storm/generic/system_call.c
@@ -37,9 +37,9 @@ return_type system_call_thread_name_set(char *name)
     return STORM_RETURN_SUCCESS;
 }
 
-return_type system_call_thread_create(void *(*start_routine) (void *), void *argument)
+return_type system_call_thread_create(uint32_t current_thread_esp, void *(*start_routine) (void *), void *argument)
 {
-    return thread_create(start_routine, argument);
+    return thread_create(current_thread_esp, start_routine, argument);
 }
 
 return_type system_call_thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter)

--- a/storm/include/storm/generic/system_call.h
+++ b/storm/include/storm/generic/system_call.h
@@ -48,6 +48,7 @@ extern return_type system_call_service_get(const char *protocol_name, service_pa
 extern return_type system_call_service_protocol_get_amount(unsigned int *number_of_protocols);
 extern return_type system_call_service_protocol_get(unsigned int *maximum_protocols, service_protocol_type *protocol_info);
 extern return_type system_call_thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter);
-extern return_type system_call_thread_create(void *(*start_routine) (void *), void *argument);
+extern return_type system_call_thread_create(uint32_t current_thread_esp, void *(*start_routine) (void *),
+    void *argument);
 extern return_type system_call_thread_name_set(char *name);
 extern return_type system_call_timer_read(time_type *timer);

--- a/storm/include/storm/generic/thread.h
+++ b/storm/include/storm/generic/thread.h
@@ -24,7 +24,7 @@ extern tss_list_type *idle_tss_node;
 extern void thread_init(void);
 extern thread_id_type thread_get_free_id(void);
 extern return_type thread_control(thread_id_type thread_id, unsigned int class, unsigned int parameter);
-extern return_type thread_create(void *(*start_routine)(void *), void *argument);
+extern return_type thread_create(uint32_t current_thread_esp, void *(*start_routine)(void *), void *argument);
 extern storm_tss_type *thread_get_tss(thread_id_type thread_id);
 extern tss_list_type *thread_link(storm_tss_type *tss);
 extern void thread_unlink(thread_id_type thread_id);

--- a/storm/x86/system_calls-auto.c
+++ b/storm/x86/system_calls-auto.c
@@ -34,7 +34,7 @@ const system_call_type system_call[] =
   { SYSTEM_CALL_PROCESS_CREATE, wrapper_process_create, 1 },
   { SYSTEM_CALL_PROCESS_NAME_SET, wrapper_process_name_set, 1 },
   { SYSTEM_CALL_PROCESS_PARENT_UNBLOCK, wrapper_process_parent_unblock, 0 },
-  { SYSTEM_CALL_THREAD_CREATE, wrapper_thread_create, 2 },
+  { SYSTEM_CALL_THREAD_CREATE, wrapper_thread_create, 3 },
   { SYSTEM_CALL_THREAD_CONTROL, wrapper_thread_control, 3 },
   { SYSTEM_CALL_THREAD_NAME_SET, wrapper_thread_name_set, 1 },
   { SYSTEM_CALL_TIMER_READ, wrapper_timer_read, 1 },

--- a/storm/x86/system_calls.rb
+++ b/storm/x86/system_calls.rb
@@ -49,7 +49,7 @@ system_calls = Hash[
   'process_name_set',             1,
   'process_parent_unblock',       0,
 
-  'thread_create',                2,
+  'thread_create',                3, # 2 ordinary arguments and one "extra" argument for old PL3 ESP value.
   'thread_control',               3,
   'thread_name_set',              1,
 
@@ -93,7 +93,7 @@ void wrapper_#{system_call}(void)
         file.puts %(
       // Restore the stack after the function call
       "addl   \$4 * #{num_parameters}, %esp\\n"\
-      )
+)
       end
 
       file.puts %[

--- a/storm/x86/wrapper.c
+++ b/storm/x86/wrapper.c
@@ -36,7 +36,7 @@ void wrapper_kernelfs_entry_read(void)
       "call   system_call_kernelfs_entry_read\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -69,7 +69,7 @@ void wrapper_mailbox_create(void)
       "call   system_call_mailbox_create\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 5, %esp\n"      
+      "addl   $4 * 5, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -98,7 +98,7 @@ void wrapper_mailbox_destroy(void)
       "call   system_call_mailbox_destroy\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -127,7 +127,7 @@ void wrapper_mailbox_flush(void)
       "call   system_call_mailbox_flush\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -157,7 +157,7 @@ void wrapper_mailbox_send(void)
       "call   system_call_mailbox_send\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 2, %esp\n"      
+      "addl   $4 * 2, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -187,7 +187,7 @@ void wrapper_mailbox_receive(void)
       "call   system_call_mailbox_receive\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 2, %esp\n"      
+      "addl   $4 * 2, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -218,7 +218,7 @@ void wrapper_service_create(void)
       "call   system_call_service_create\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 3, %esp\n"      
+      "addl   $4 * 3, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -247,7 +247,7 @@ void wrapper_service_destroy(void)
       "call   system_call_service_destroy\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -278,7 +278,7 @@ void wrapper_service_get(void)
       "call   system_call_service_get\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 3, %esp\n"      
+      "addl   $4 * 3, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -308,7 +308,7 @@ void wrapper_service_protocol_get(void)
       "call   system_call_service_protocol_get\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 2, %esp\n"      
+      "addl   $4 * 2, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -337,7 +337,7 @@ void wrapper_service_protocol_get_amount(void)
       "call   system_call_service_protocol_get_amount\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -370,7 +370,7 @@ void wrapper_dma_transfer(void)
       "call   system_call_dma_transfer\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 5, %esp\n"      
+      "addl   $4 * 5, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -399,7 +399,7 @@ void wrapper_dma_transfer_cancel(void)
       "call   system_call_dma_transfer_cancel\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -429,7 +429,7 @@ void wrapper_dma_register(void)
       "call   system_call_dma_register\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 2, %esp\n"      
+      "addl   $4 * 2, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -458,7 +458,7 @@ void wrapper_dma_unregister(void)
       "call   system_call_dma_unregister\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -488,7 +488,7 @@ void wrapper_irq_register(void)
       "call   system_call_irq_register\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 2, %esp\n"      
+      "addl   $4 * 2, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -517,7 +517,7 @@ void wrapper_irq_unregister(void)
       "call   system_call_irq_unregister\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -546,7 +546,7 @@ void wrapper_irq_wait(void)
       "call   system_call_irq_wait\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -575,7 +575,7 @@ void wrapper_irq_acknowledge(void)
       "call   system_call_irq_acknowledge\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -606,7 +606,7 @@ void wrapper_memory_allocate(void)
       "call   system_call_memory_allocate\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 3, %esp\n"      
+      "addl   $4 * 3, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -635,7 +635,7 @@ void wrapper_memory_deallocate(void)
       "call   system_call_memory_deallocate\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -666,7 +666,7 @@ void wrapper_memory_reserve(void)
       "call   system_call_memory_reserve\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 3, %esp\n"      
+      "addl   $4 * 3, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -696,7 +696,7 @@ void wrapper_memory_get_physical_address(void)
       "call   system_call_memory_get_physical_address\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 2, %esp\n"      
+      "addl   $4 * 2, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -727,7 +727,7 @@ void wrapper_port_range_register(void)
       "call   system_call_port_range_register\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 3, %esp\n"      
+      "addl   $4 * 3, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -756,7 +756,7 @@ void wrapper_port_range_unregister(void)
       "call   system_call_port_range_unregister\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -785,7 +785,7 @@ void wrapper_process_create(void)
       "call   system_call_process_create\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -814,7 +814,7 @@ void wrapper_process_name_set(void)
       "call   system_call_process_name_set\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -860,13 +860,14 @@ void wrapper_thread_create(void)
 
       // Push all arguments. This approach pretty smart; it utilizes the fact that the stack grows downwards
       // so the "next parameter to push" is always in the same memory location. :)
-      "pushl 32 + 4 + 2 * 4(%esp)\n"
-      "pushl 32 + 4 + 2 * 4(%esp)\n"
+      "pushl 32 + 4 + 3 * 4(%esp)\n"
+      "pushl 32 + 4 + 3 * 4(%esp)\n"
+      "pushl 32 + 4 + 3 * 4(%esp)\n"
 
       "call   system_call_thread_create\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 2, %esp\n"      
+      "addl   $4 * 3, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -881,7 +882,7 @@ void wrapper_thread_create(void)
 
       // Adjust the stack for the fact that EAX isn't being popped.
       "addl   $4, %esp\n"
-      "lret   $4 * 2\n");
+      "lret   $4 * 3\n");
 }
 
 void wrapper_thread_control(void)
@@ -897,7 +898,7 @@ void wrapper_thread_control(void)
       "call   system_call_thread_control\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 3, %esp\n"      
+      "addl   $4 * 3, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -926,7 +927,7 @@ void wrapper_thread_name_set(void)
       "call   system_call_thread_name_set\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"
@@ -955,7 +956,7 @@ void wrapper_timer_read(void)
       "call   system_call_timer_read\n"      
 
       // Restore the stack after the function call
-      "addl   $4 * 1, %esp\n"      
+      "addl   $4 * 1, %esp\n"
 
       // Simulate a popa, without overwriting EAX (since it contains the return value from the system call).
       "popl   %edi\n"


### PR DESCRIPTION
It would previously use the PL0 stack for the newly created thread. This commit fixes this, so that the PL3 stack (which is much less limited in size) is used instead.

(This change was a drive-by change while I was researching the root cause for some issues mentioned in #120)