### PR TITLE
[servers/console] Fix reentrancy issues

### DIFF
--- a/servers/system/console/console.c
+++ b/servers/system/console/console.c
@@ -14,6 +14,7 @@ volatile unsigned int number_of_consoles = 0;
 character_type *screen = (character_type *) NULL;
 volatile console_type *current_console = NULL;
 console_type *console_list = NULL;
+volatile bool console_open_lock = FALSE;
 ipc_structure_type video_structure;
 volatile bool has_video = FALSE;
 volatile unsigned int console_id = 0;

--- a/servers/system/console/console.h
+++ b/servers/system/console/console.h
@@ -122,6 +122,7 @@ extern volatile console_type *current_console;
 extern volatile unsigned int number_of_consoles;
 extern console_type *console_list;
 extern volatile console_type *console_shortcut[];
+extern volatile bool console_open_lock;
 
 extern void handle_connection(mailbox_id_type *reply_mailbox_id) NORETURN;
 extern void console_link(console_type *console);

--- a/storm/x86/thread.c
+++ b/storm/x86/thread.c
@@ -362,7 +362,7 @@ static return_type thread_delete(storm_tss_type *tss)
     // Free IRQs we might have allocated.
     irq_free_all(tss->thread_id);
 
-    // Free port ranges possibl7 allocated.
+    // Free port ranges possibly allocated.
     // FIXME: This doesn't seem to really work...
     // port_range_free_all (thread_id);
 
@@ -376,7 +376,11 @@ static return_type thread_delete(storm_tss_type *tss)
         process_parent_unblock();
     }
 
-    // FIXME: Add this thread to a list of threads that the idle thread should delete, and implement this in the idle thread.
+    // FIXME: Add this thread to a list of threads that the idle thread
+    // should delete, and implement this in the idle thread. For now,
+    // all resources used by the thread is leaked and nothing handles the
+    // case where all threads are terminated and the whole process should
+    // be removed from the system.
     return RETURN_SUCCESS;
 }
 


### PR DESCRIPTION
There were a few:

- The `handle_connection` method would save away the mailbox IDs for
its connection to the video server (VGA), for later use. It would then
sit and _block on receive_ on the input mailbox from it, effectively
blocking other threads from using it. A typical reentrancy bug.
- The code for opening up new consoles would call `video_mode_set()`,
using the above data structure, but if multiple consoles were being
opened simultaneously (which happen now since we run servers in parallel
at boot), the same thing could happen - multiple threads tried to use a
single connection to the VGA server, which works very poorly. I added a
poor man's semaphore to work around this.