### PR TITLE
[servers/console] Add new activation flag

### DIFF
--- a/libraries/console/console.c
+++ b/libraries/console/console.c
@@ -1,9 +1,7 @@
 // Abstract: Console library.
 // Author: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 1999-2000 chaos development
-// © Copyright 2013 chaos development
-// © Copyright 2015-2016 chaos development
+// © Copyright 1999 chaos development
 
 // See The chaos Programming Reference Manual for more information about the functions in this library.
 
@@ -52,10 +50,10 @@ return_type console_init(console_structure_type *console_structure, tag_type *ta
 
 // Allocate and open a new console with the specified attributes.
 
-// FIXME: If input parameters are all zero (except for mode_type), a default mode with the requested type should be set and the
-// attributes of that mode should be returned.
-return_type console_open(console_structure_type *console_structure, unsigned int width, unsigned int height, unsigned int depth,
-                         int mode_type)
+// FIXME: If input parameters are all zero (except for mode_type), a default mode with the requested
+// type should be set and the attributes of that mode should be returned.
+return_type console_open(console_structure_type *console_structure, unsigned int width,
+                         unsigned int height, unsigned int depth, int mode_type, bool activate)
 {
     if (!console_structure->initialised)
     {
@@ -67,6 +65,7 @@ return_type console_open(console_structure_type *console_structure, unsigned int
     console_attribute.height = height;
     console_attribute.depth = depth;
     console_attribute.mode_type = mode_type;
+    console_attribute.activate = activate;
 
     message_parameter_type message_parameter;
     message_parameter.protocol = IPC_PROTOCOL_CONSOLE;
@@ -82,8 +81,8 @@ return_type console_open(console_structure_type *console_structure, unsigned int
 }
 
 // Change the attributes of the current console.
-return_type console_mode_set(console_structure_type *console_structure, unsigned int width, unsigned int height,
-                             unsigned int depth, int mode_type)
+return_type console_mode_set(console_structure_type *console_structure, unsigned int width,
+                             unsigned int height, unsigned int depth, int mode_type)
 {
     if (!console_structure->initialised)
     {
@@ -109,7 +108,8 @@ return_type console_mode_set(console_structure_type *console_structure, unsigned
 }
 
 // Change the size (text rows and columns, not mode!) of the current console.
-return_type console_resize(console_structure_type *console_structure, unsigned int width, unsigned int height)
+return_type console_resize(console_structure_type *console_structure, unsigned int width,
+                           unsigned int height)
 {
     if (!console_structure->initialised)
     {

--- a/libraries/console/console.c
+++ b/libraries/console/console.c
@@ -49,23 +49,13 @@ return_type console_init(console_structure_type *console_structure, tag_type *ta
 }
 
 // Allocate and open a new console with the specified attributes.
-
-// FIXME: If input parameters are all zero (except for mode_type), a default mode with the requested
-// type should be set and the attributes of that mode should be returned.
-return_type console_open(console_structure_type *console_structure, unsigned int width,
-                         unsigned int height, unsigned int depth, int mode_type, bool activate)
+return_type console_open(console_structure_type *console_structure,
+                         ipc_console_attribute_type console_attribute)
 {
     if (!console_structure->initialised)
     {
         return CONSOLE_RETURN_SERVICE_UNAVAILABLE;
     }
-
-    ipc_console_attribute_type console_attribute;
-    console_attribute.width = width;
-    console_attribute.height = height;
-    console_attribute.depth = depth;
-    console_attribute.mode_type = mode_type;
-    console_attribute.activate = activate;
 
     message_parameter_type message_parameter;
     message_parameter.protocol = IPC_PROTOCOL_CONSOLE;
@@ -76,7 +66,6 @@ return_type console_open(console_structure_type *console_structure, unsigned int
 
     system_call_mailbox_send(console_structure->ipc_structure.output_mailbox_id, &message_parameter);
 
-    // FIXME: Wait for return value to ensure that the operation was successful.
     return CONSOLE_RETURN_SUCCESS;
 }
 

--- a/libraries/console/functions.h
+++ b/libraries/console/functions.h
@@ -1,9 +1,7 @@
 // Abstract: Function definitions for the console library.
 // Author: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 1999-2000 chaos development
-// © Copyright 2013 chaos development
-// © Copyright 2015-2016 chaos development
+// © Copyright 1999 chaos development
 
 #pragma once
 
@@ -12,22 +10,29 @@
 
 C_EXTERN_BEGIN
 
-extern return_type console_init(console_structure_type *console_structure, tag_type *tag, unsigned int connection_class);
-extern return_type console_open(console_structure_type *console_structure, unsigned int width, unsigned int height,
-                                unsigned int depth, int mode_type);
-extern return_type console_mode_set(console_structure_type *console_structure, unsigned int width, unsigned int height,
-                                    unsigned int depth, int mode_type);
+extern return_type console_init(console_structure_type *console_structure, tag_type *tag,
+                                unsigned int connection_class);
+extern return_type console_open(console_structure_type *console_structure, unsigned int width,
+                                unsigned int height, unsigned int depth, int mode_type, bool activate);
+extern return_type console_mode_set(console_structure_type *console_structure, unsigned int width,
+                                    unsigned int height, unsigned int depth, int mode_type);
 
-extern return_type console_resize(console_structure_type *console_structure, unsigned int width, unsigned int height);
+extern return_type console_resize(console_structure_type *console_structure, unsigned int width,
+                                  unsigned int height);
 extern return_type console_print(console_structure_type *console_structure, const char *string);
-extern return_type console_print_formatted(console_structure_type *console_structure, const char *string, ...);
+extern return_type console_print_formatted(console_structure_type *console_structure,
+                                           const char *string, ...);
 // __attribute__ ((format (printf, 1, 2)));
 extern return_type console_clear(console_structure_type *console_structure);
-extern return_type console_cursor_move(console_structure_type *console_structure, unsigned int x, unsigned int y);
-extern return_type console_attribute_set(console_structure_type *console_structure, int foreground, int background, int attributes);
-extern return_type console_cursor_appearance_set(console_structure_type *console_structure, bool visibility, bool block);
+extern return_type console_cursor_move(console_structure_type *console_structure, unsigned int x,
+                                       unsigned int y);
+extern return_type console_attribute_set(console_structure_type *console_structure, int foreground,
+                                         int background, int attributes);
+extern return_type console_cursor_appearance_set(console_structure_type *console_structure,
+                                                 bool visibility, bool block);
 extern return_type console_use_keyboard(console_structure_type *console_structure, bool which, int type);
 extern return_type console_use_mouse(console_structure_type *console_structure, bool which);
-extern return_type console_event_wait(console_structure_type *console_structure, void *event_data, int *type, bool block);
+extern return_type console_event_wait(console_structure_type *console_structure, void *event_data,
+                                      int *type, bool block);
 
 C_EXTERN_END

--- a/libraries/console/functions.h
+++ b/libraries/console/functions.h
@@ -12,8 +12,8 @@ C_EXTERN_BEGIN
 
 extern return_type console_init(console_structure_type *console_structure, tag_type *tag,
                                 unsigned int connection_class);
-extern return_type console_open(console_structure_type *console_structure, unsigned int width,
-                                unsigned int height, unsigned int depth, int mode_type, bool activate);
+extern return_type console_open(console_structure_type *console_structure,
+                                ipc_console_attribute_type console_attribute);
 extern return_type console_mode_set(console_structure_type *console_structure, unsigned int width,
                                     unsigned int height, unsigned int depth, int mode_type);
 

--- a/libraries/console/types.h
+++ b/libraries/console/types.h
@@ -1,7 +1,7 @@
 // Abstract: Console library types.
 // Author: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 2000, 2013 chaos development.
+// © Copyright 2000 chaos development.
 
 #pragma once
 

--- a/libraries/ipc/console.h
+++ b/libraries/ipc/console.h
@@ -66,6 +66,6 @@ typedef struct
     unsigned int mode_type;
 
     // Indicates that the console should be activated upon creation. Can only be done once; if
-    // there is already an active console, this flag will be ignored by the console server.
+    // a console is already active, this flag will be ignored by the console server.
     bool activate;
 } ipc_console_attribute_type;

--- a/libraries/ipc/console.h
+++ b/libraries/ipc/console.h
@@ -1,8 +1,7 @@
 // Abstract: Console server IPC message types.
 // Author: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 1999-2000 chaos development
-// © Copyright 2013-2017 chaos development
+// © Copyright 1999 chaos development
 
 #pragma once
 
@@ -51,8 +50,22 @@ typedef struct
 // Physical console attribute type.
 typedef struct
 {
+    // The width in pixels (for VIDEO_MODE_TYPE_GRAPHIC) or characters (for VIDEO_MODE_TYPE_TEXT)
+    // of the console being opened.
     unsigned int width;
+
+    // The height in pixels (for VIDEO_MODE_TYPE_GRAPHIC) or lines (for VIDEO_MODE_TYPE_TEXT)
+    // of the console being opened.
     unsigned int height;
+
+    // For VIDEO_MODE_TYPE_GRAPHIC, indicates the depth in bits (15, 16, 24 etc) of the mode being
+    // requested.
     unsigned int depth;
+
+    // Set to either VIDEO_MODE_TYPE_TEXT or VIDEO_MODE_TYPE_GRAPHIC.
     unsigned int mode_type;
+
+    // Indicates that the console should be activated upon creation. Can only be done once; if
+    // there is already an active console, this flag will be ignored by the console server.
+    bool activate;
 } ipc_console_attribute_type;

--- a/programs/cluido/init.c
+++ b/programs/cluido/init.c
@@ -30,8 +30,15 @@ int main(void)
         return -1;
     }
 
-    if (console_open(&console_structure, 80, 50, 4, VIDEO_MODE_TYPE_TEXT, TRUE) !=
-            CONSOLE_RETURN_SUCCESS)
+    ipc_console_attribute_type console_attribute = {
+        width: 80,
+        height: 50,
+        depth: 4,
+        mode_type: VIDEO_MODE_TYPE_TEXT,
+        activate: TRUE
+    };
+
+    if (console_open(&console_structure, console_attribute) != CONSOLE_RETURN_SUCCESS)
     {
         return -1;
     }

--- a/programs/cluido/init.c
+++ b/programs/cluido/init.c
@@ -24,12 +24,14 @@ int main(void)
     system_thread_name_set("Initialising");
 
     // First of all, initiate a connection to the console service.
-    if (console_init(&console_structure, &empty_tag, IPC_CONSOLE_CONNECTION_CLASS_CLIENT) != CONSOLE_RETURN_SUCCESS)
+    if (console_init(&console_structure, &empty_tag, IPC_CONSOLE_CONNECTION_CLASS_CLIENT) !=
+            CONSOLE_RETURN_SUCCESS)
     {
         return -1;
     }
 
-    if (console_open(&console_structure, 80, 50, 4, VIDEO_MODE_TYPE_TEXT) != CONSOLE_RETURN_SUCCESS)
+    if (console_open(&console_structure, 80, 50, 4, VIDEO_MODE_TYPE_TEXT, TRUE) !=
+            CONSOLE_RETURN_SUCCESS)
     {
         return -1;
     }

--- a/servers/system/console/connection.c
+++ b/servers/system/console/connection.c
@@ -136,7 +136,11 @@ static void connection_client(message_parameter_type *message_parameter, console
                 (*our_application)->ipc_structure.input_mailbox_id = ipc_structure->input_mailbox_id;
                 (*our_application)->ipc_structure.output_mailbox_id = ipc_structure->output_mailbox_id;
 
-                if (current_console == NULL)
+                // The client opening a console can set the activate flag, to enable switching to
+                // the newly created console - but only if there isn't already an active console.
+                // This is used by cluido, to take precedence over all other servers and programs
+                // opening consoles.
+                if (console_attribute->activate && current_console == NULL)
                 {
                     current_console = *our_console;
                     (*our_console)->output = screen;

--- a/servers/system/log/log.c
+++ b/servers/system/log/log.c
@@ -156,7 +156,7 @@ static return_type handle_server_logging(void)
         return -1;
     }
 
-    if (console_open(&console_structure_server, 80, 50, 4, VIDEO_MODE_TYPE_TEXT) !=
+    if (console_open(&console_structure_server, 80, 50, 4, VIDEO_MODE_TYPE_TEXT, FALSE) !=
             CONSOLE_RETURN_SUCCESS)
     {
         return -1;
@@ -207,7 +207,7 @@ static void handle_kernel_logging(void *argument UNUSED)
         return;
     }
 
-    if (console_open(&console_structure_kernel, 80, 50, 4, VIDEO_MODE_TYPE_TEXT) !=
+    if (console_open(&console_structure_kernel, 80, 50, 4, VIDEO_MODE_TYPE_TEXT, FALSE) !=
             CONSOLE_RETURN_SUCCESS)
     {
         return;

--- a/servers/system/log/log.c
+++ b/servers/system/log/log.c
@@ -1,5 +1,5 @@
-// Abstract: Log server for chaos. This server's purpose is to collect debug and/or warning messages from servers and
-// from the kernel.
+// Abstract: Log server for chaos. This server's purpose is to collect debug and/or warning messages
+// from servers and from the kernel.
 // Authors: Per Lundberg <per@chaosdev.io>
 //          Henrik Hallin <hal@chaosdev.org>
 //
@@ -156,8 +156,15 @@ static return_type handle_server_logging(void)
         return -1;
     }
 
-    if (console_open(&console_structure_server, 80, 50, 4, VIDEO_MODE_TYPE_TEXT, FALSE) !=
-            CONSOLE_RETURN_SUCCESS)
+    ipc_console_attribute_type console_attribute = {
+        width: 80,
+        height: 50,
+        depth: 4,
+        mode_type: VIDEO_MODE_TYPE_TEXT,
+        activate: FALSE
+    };
+
+    if (console_open(&console_structure_server, console_attribute) != CONSOLE_RETURN_SUCCESS)
     {
         return -1;
     }
@@ -165,12 +172,14 @@ static return_type handle_server_logging(void)
     console_clear(&console_structure_server);
 
     // Print the titlebar.
-    console_attribute_set(&console_structure_server, TITLE_FOREGROUND, TITLE_BACKGROUND, TITLE_ATTRIBUTE);
-    console_print(&console_structure_server, " " PACKAGE_NAME " version " PACKAGE_VERSION " server console.\e[K\n");
+    console_attribute_set(&console_structure_server, TITLE_FOREGROUND, TITLE_BACKGROUND,
+                          TITLE_ATTRIBUTE);
+    console_print(&console_structure_server,
+                  " " PACKAGE_NAME " version " PACKAGE_VERSION " server console.\e[K\n");
 
-    // Main loop.
     system_thread_name_set("Service handler");
 
+    // Main loop.
     while (TRUE)
     {
         mailbox_id_type reply_mailbox_id;
@@ -207,8 +216,15 @@ static void handle_kernel_logging(void *argument UNUSED)
         return;
     }
 
-    if (console_open(&console_structure_kernel, 80, 50, 4, VIDEO_MODE_TYPE_TEXT, FALSE) !=
-            CONSOLE_RETURN_SUCCESS)
+    ipc_console_attribute_type console_attribute = {
+        width: 80,
+        height: 50,
+        depth: 4,
+        mode_type: VIDEO_MODE_TYPE_TEXT,
+        activate: FALSE
+    };
+
+    if (console_open(&console_structure_kernel, console_attribute) != CONSOLE_RETURN_SUCCESS)
     {
         return;
     }
@@ -216,8 +232,10 @@ static void handle_kernel_logging(void *argument UNUSED)
     console_clear(&console_structure_kernel);
 
     // Print the titlebar.
-    console_attribute_set(&console_structure_kernel, TITLE_FOREGROUND, TITLE_BACKGROUND, TITLE_ATTRIBUTE);
-    console_print(&console_structure_kernel, " " PACKAGE_NAME " version " PACKAGE_VERSION " kernel console.\e[K\n");
+    console_attribute_set(&console_structure_kernel, TITLE_FOREGROUND, TITLE_BACKGROUND,
+                          TITLE_ATTRIBUTE);
+    console_print(&console_structure_kernel,
+                  " " PACKAGE_NAME " version " PACKAGE_VERSION " kernel console.\e[K\n");
 
     while (TRUE)
     {
@@ -230,14 +248,11 @@ static void handle_kernel_logging(void *argument UNUSED)
 
 return_type main(void)
 {
-    // Initialise the memory library.
     memory_init();
-
-    // Set our name.
     system_process_name_set(PACKAGE_NAME);
 
-    // Unblock any servers that may be waiting after us. FIXME: This should be done later than this to eliminate
-    // unecessary waiting.
+    // Unblock any servers that may be waiting after us.
+    // FIXME: This should be done later than this to eliminate unecessary waiting.
     system_call_process_parent_unblock();
 
     system_thread_create(handle_kernel_logging, NULL);

--- a/storm/generic/mailbox.c
+++ b/storm/generic/mailbox.c
@@ -283,10 +283,10 @@ return_type mailbox_send(mailbox_id_type mailbox_id, message_parameter_type *mes
         return STORM_RETURN_MAILBOX_MESSAGE_TOO_LARGE;
     }
 
-    // Block or return, depending on how we was called.
     if (message_parameter->length + sizeof (message_parameter_type) >
         mailbox->free_size)
     {
+        // Block or return, depending on how we was called.
         if (message_parameter->block)
         {
             // Block until receiver reads messages so that there is room for us.
@@ -306,8 +306,7 @@ return_type mailbox_send(mailbox_id_type mailbox_id, message_parameter_type *mes
         }
     }
 
-    // When we come here, we are guaranteed to send to the mailbox.
-
+    // When we come here, the mailbox is guaranteed to have room for our message.
     DEBUG_MESSAGE(VERBOSE_DEBUG, "Delivering...");
 
     message = memory_global_allocate(sizeof (message_type) + message_parameter->length);


### PR DESCRIPTION
This flag is to be used by cludio, and by cluido only, to ensure that
the cluido console is always made visible when created; other servers
have a lower pirority. This is important to give the user a decent
experience when running e.g. the chaos Docker container, using a
pre-compiled chaos .iso image etc.

Closes #45; there are still some issues with the kernel log console (as
being created by the log server) not being visible, but I will create a
separate issue for that before merging this one.