### PR TITLE
[libraries/system] Fix bug in system_call_dma_register

### DIFF
--- a/libraries/system/system_calls.h
+++ b/libraries/system/system_calls.h
@@ -467,7 +467,7 @@ static inline return_type system_call_dma_register(unsigned int channel, void **
                  "pushl %3\n"
                  "lcall %4, $0"
                  : "=a" (return_value),
-                   "=ri" (*dma_buffer)
+                   "=m" (*dma_buffer)
                  : "ri" (dma_buffer),
                    "ri" (channel),
                    "n" (SYSTEM_CALL_DMA_REGISTER << 3));


### PR DESCRIPTION
The bug would cause a crash in processes using this system call. This
was experienced while working on #140, so this PR is a prerequisite to
getting that PR into a mergeable shape.