### PR TITLE
[servers/fat] Fix fat_file_open case bug

### DIFF
--- a/servers/file_system/fat/fat_file_open.c
+++ b/servers/file_system/fat/fat_file_open.c
@@ -14,12 +14,6 @@ bool fat_file_open(fat_info_type *fat_info, ipc_file_open_type *open)
     unsigned int elements = MAX_PATH_ELEMENTS;
     char *path[MAX_PATH_ELEMENTS];
     fat_entry_type *fat_entry;
-    bool done = FALSE;
-    uint32_t cluster_number;
-    unsigned int entry = 0;
-    unsigned int lfn_entries_in_row = 0;
-    char long_file_name[MAX_FILE_NAME_LENGTH];
-    bool has_lfn;
 
     // Read the directory where this file is located. If it is a subdirectory, we need to read every parent directory. First, we
     // split the directory name into its logical components.
@@ -39,119 +33,28 @@ bool fat_file_open(fat_info_type *fat_info, ipc_file_open_type *open)
         return FALSE;
     }
 
-    // Now, parse the directory until we found our boy.
-    for (entry = 0; fat_entry[entry].name[0] != 0x00 && !done; entry++)
+    // The last element of a /path/to/file => the actual file name that
+    // can be used for scanning the FAT entries for the directory in
+    // question.
+    const char *file_name = path[elements - 1];
+    fat_entry_type *matching_fat_entry = get_entry_by_name(fat_entry, file_name);
+
+    if (matching_fat_entry == NULL)
     {
-        int counter;
-        char filename[13];
-
-        // First of all, make sure this isn't a long file entry.
-        if (fat_entry[entry].read_only == 1 &&
-            fat_entry[entry].hidden == 1 &&
-            fat_entry[entry].system == 1 &&
-            fat_entry[entry].volume_id == 1)
-        {
-            lfn_entries_in_row++;
-            continue;
-        }
-
-        // Also, make sure the file hasn't been deleted.
-        if (fat_entry[entry].name[0] == 0xE5)
-        {
-            continue;
-        }
-
-        // We don't want the volume ID either.
-        if (fat_entry[entry].volume_id == 1)
-        {
-            continue;
-        }
-
-        // Replace all spaces in the file name with zeroes, so that we get a NULL terminated string.
-        for (counter = 0; counter < 8; counter++)
-        {
-            if (fat_entry[entry].name[counter] == 0x20)
-            {
-                fat_entry[entry].name[counter] = 0;
-                break;
-            }
-        }
-
-        for (counter = 0; counter < 3; counter++)
-        {
-            if (fat_entry[entry].extension[counter] == 0x20)
-            {
-                fat_entry[entry].extension[counter] = 0;
-                break;
-            }
-        }
-
-        string_copy_max(filename, fat_entry[entry].name, 8);
-
-        // Make sure the string is zero terminated.
-        filename[8] = 0;
-
-        // If we have a file extension, add it too.
-        if (fat_entry[entry].extension[0] != 0)
-        {
-            unsigned int length = string_length(filename);
-            filename[string_length(filename)] = '.';
-            string_copy_max(&filename[string_length(filename)], fat_entry[entry].extension, 3);
-            filename[length + string_length(fat_entry[entry].extension)] = '\0';
-        }
-
-        // Get the long filename of the file (if any).
-        read_long_file_name(fat_entry, entry, lfn_entries_in_row, long_file_name);
-        lfn_entries_in_row = 0;
-
-        if (long_file_name[0] != '\0')
-        {
-            has_lfn = TRUE;
-        }
-        else
-        {
-            has_lfn = FALSE;
-        }
-
-        if (has_lfn)
-        {
-            if (string_compare(long_file_name, path[elements - 1]) == 0)
-            {
-                done = TRUE;
-            }
-        }
-        else
-        {
-            if (string_compare(filename, path[elements - 1]) == 0)
-            {
-                done = TRUE;
-            }
-        }
-    }
-
-    // The entry we are after is actually one lower than what we've got.
-    if (entry > 0)
-    {
-        entry--;
-    }
-
-    // Did we fall through to the end of the list?
-    if (fat_entry[entry].name[0] == '\0')
-    {
-        //    log_print (&log_structure, LOG_URGENCY_ERROR, "Jadå, glassen e slut!");
         return FALSE;
     }
 
     // Get the starting cluster of the file.
-    cluster_number = ((fat_entry[entry].first_cluster_number_high << 16) +
-                      fat_entry[entry].first_cluster_number_low);
+    uint32_t cluster_number =
+        ((matching_fat_entry->first_cluster_number_high << 16) +
+         matching_fat_entry->first_cluster_number_low);
 
     // Add this file to our list of open files.
     fat_open_file[number_of_open_files].file_handle = open->file_handle;
     fat_open_file[number_of_open_files].start_cluster_number =
         fat_open_file[number_of_open_files].current_cluster_number = cluster_number;
     fat_open_file[number_of_open_files].file_position = 0;
-    fat_open_file[number_of_open_files].file_size = fat_entry[entry].file_size;
+    fat_open_file[number_of_open_files].file_size = matching_fat_entry->file_size;
     number_of_open_files++;
 
     return TRUE;


### PR DESCRIPTION
I discovered another incarnation of #107. The previous fix (in #130)
fixed `fat_file_get_info`, _but_ the code was still broken for
`fat_file_open`. There was also a weird bug making "no matching file"
use the last file that happened to exist in the directory suggested (!).

In addition to all of this, `fat_file_open` stupidly duplicated code
already present elsewhere. All of this is fixed in this commit.

This was the root cause for #132. In other words: Fixes #132.