### PR TITLE
Enable unit tests in Travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 
 matrix:
   include:
@@ -49,13 +49,13 @@ before_script:
  - sudo apt-get update
  - sudo apt-get install
      dosfstools
+     gcc-multilib
      genisoimage
      grub
      mtools
      nasm
  - ./install_cmocka.sh
 
-# Tests are disabled for now since cmocka don't work on Trusty Tahr.
 script:
  - bundle exec rubocop
- - bundle exec rake
+ - bundle exec rake default test

--- a/Rakefile
+++ b/Rakefile
@@ -69,9 +69,14 @@ task build_storm_tests: :storm do
   sh "cd storm_tests && #{RAKE_COMMAND}"
 end
 
-desc 'Runs the unit tests'
-task tests: [:build_storm_tests] do
-  sh "cd storm_tests && #{RAKE_COMMAND} tests"
+if TARGET_ARCH == 'x86'
+  desc 'Runs the unit tests'
+  task test: [:build_storm_tests] do
+    sh "cd storm_tests && #{RAKE_COMMAND} test"
+  end
+elsif TARGET_ARCH == 'raspberrypi'
+  # No-op since we don't support the tests on this architecture at the moment.
+  task :test
 end
 
 task libraries: [:storm] do |folder|

--- a/install_cmocka.sh
+++ b/install_cmocka.sh
@@ -1,10 +1,12 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e -o pipefail
 
 cd /tmp
 rm -rf cmocka*
-wget https://cmocka.org/files/1.0/cmocka-1.0.1.tar.xz
-tar xf cmocka-1.0.1.tar.xz 
-cd cmocka-1.0.1
+wget https://cmocka.org/files/1.1/cmocka-1.1.5.tar.xz
+tar xf cmocka-1.1.5.tar.xz
+cd cmocka-1.1.5
 mkdir build
 cd build
 cmake -DCMAKE_C_FLAGS=-m32 ..

--- a/storm_tests/Rakefile
+++ b/storm_tests/Rakefile
@@ -25,9 +25,9 @@ task build_tests: :default do
   end
 end
 
-task :tests do
+task :test do
   subfolders.each do |folder|
-    sh "cd #{folder} && #{RAKE_COMMAND} tests"
+    sh "cd #{folder} && #{RAKE_COMMAND} test"
   end
 end
 

--- a/storm_tests/storm_tests.rake
+++ b/storm_tests/storm_tests.rake
@@ -41,5 +41,5 @@ INCLUDES = %w[
 ].freeze
 
 def run_test(test)
-  sh "./#{test} 2>&1 | #{Rake.application.options.rakelib.first}/../tools/colorize.rb"
+  sh "./#{test} 2>&1 | RUBYOPT='' #{Rake.application.options.rakelib.first}/../tools/colorize.rb"
 end

--- a/storm_tests/x86/Rakefile
+++ b/storm_tests/x86/Rakefile
@@ -51,7 +51,7 @@ file OUTPUT => OBJECTS do |t|
   end
 end
 
-task :tests do
+task :test do
   puts
   run_test OUTPUT
 end


### PR DESCRIPTION
Also upgraded `cmocka` to a version that works better on Debian Buster.

The reason why this was disabled a long time ago was because Travis only
supported Ubuntu Trusty (i.e. 14.04) as its newest Ubuntu version, where
`cmocka` didn't work. Since Xenial (16.04) is now available, this should
hopefully no longer be an issue.