### PR TITLE
[storm] Refactor IPC to use circular queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.orig
 
 storm_tests/x86/x86_tests
+storm_tests/generic/generic_tests
+
 storm/current-arch
 storm/include/storm/current-arch
 storm/raspberrypi/storm

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@
 TARGET_ARCH = ENV['ARCH']
 
 FOLDERS = if TARGET_ARCH == 'x86'
-  %i[storm libraries programs servers].freeze
+  %i[storm libraries programs servers storm_tests].freeze
 elsif TARGET_ARCH == 'raspberrypi'
   # Nothing else has been ported to this arch yet.
   [:storm].freeze

--- a/libraries/ipc/ipc.c
+++ b/libraries/ipc/ipc.c
@@ -176,8 +176,9 @@ return_type ipc_service_connection_request(ipc_structure_type *ipc_structure)
     message_parameter_type message_parameter;
     uint8_t data[100];
 
-    // FIXME: Make it possible to specify the size of the mailbox. For now, we just set it to one meg and hope it's enough.
-    if (system_call_mailbox_create(&ipc_structure->input_mailbox_id, 1 * MB, PROCESS_ID_NONE,
+    // FIXME: Make it possible to specify the size of the mailbox. For now, we just set it to a
+    // fixed size and hope it's enough.
+    if (system_call_mailbox_create(&ipc_structure->input_mailbox_id, 64 * KB, PROCESS_ID_NONE,
             CLUSTER_ID_NONE, THREAD_ID_NONE) != STORM_RETURN_SUCCESS)
     {
         // FIXME: Handle the possible causes of this.

--- a/storm/generic/Rakefile
+++ b/storm/generic/Rakefile
@@ -9,6 +9,7 @@ def objects
       avl_rotate.o
       avl_update.o
       avl_delete.o
+      circular_queue.o
       debug.o
       idle.o
       init.o

--- a/storm/generic/circular_queue.c
+++ b/storm/generic/circular_queue.c
@@ -1,0 +1,237 @@
+// Abstract: Circular queue implementation
+// Author: Per Lundberg <per@chaosdev.io>
+//
+// © Copyright 1999 chaos development
+
+#include <storm/generic/circular_queue.h>
+#include <storm/generic/defines.h>
+#include <storm/generic/memory.h>
+
+void circular_queue_initialize(circular_queue_type *queue, int queue_size)
+{
+    queue->head = queue->data;
+    queue->tail = NULL;
+    queue->size = queue_size - sizeof(circular_queue_type);
+    queue->data_end = queue->data + queue->size;
+}
+
+bool circular_queue_enqueue(circular_queue_type *queue, void *message, int length)
+{
+    int total_length = length + sizeof(int);
+
+    if (queue->head == queue->tail)
+    {
+        // The head has reached the tail. There is absolutely no free space in this queue. Indicate
+        // this to the caller.
+        return FALSE;
+    }
+
+    if (queue->head > queue->tail)
+    {
+        //
+        // The queue looks roughly like this:
+        //
+        // +--------------------+------+------+------+-------------------------+
+        // | free tail space    | msg1 | msg2 | msg3 | free head space         |
+        // +--------------------+------+------+------+-------------------------+
+        //                      ^                    ^
+        //                    tail                  head
+        //
+        // Note: this branch also handles the tail == NULL case. Remember that NULL is just a
+        // convenient alias for 0 in C pointer arithmetics.
+        //
+        int free_space_after_head = queue->data_end -
+                                    queue->head;
+
+        if (free_space_after_head >= total_length)
+        {
+            if (queue->tail == NULL)
+            {
+                // This is the first message in the queue; the tail pointer must be initialized.
+                queue->tail = queue->head;
+            }
+
+            *(int *)queue->head = length;
+            memory_copy(queue->head + sizeof(int), message, length);
+
+            queue->head += total_length;
+
+            if (queue->head >= queue->data_end)
+            {
+                // All space at the end of the queue has been used up; move the pointer to the
+                // free tail space.
+                queue->head = queue->data;
+            }
+
+            return TRUE;
+        }
+        else
+        {
+            if (queue->tail == NULL)
+            {
+                // There is no tail space at all, since there are no messages in the queue. This
+                // likely means that the message is too large to fit in the head space.
+                return FALSE;
+            }
+
+            int free_space_before_tail = queue->tail -
+                                         queue->data;
+
+            if (free_space_before_tail >= total_length)
+            {
+                *(int *)queue->data = length;
+                memory_copy(queue->data + sizeof(int), message, length);
+
+                queue->head = queue->data + total_length;
+
+                // No need to check if queue->tail is NULL at this stage since it's already been
+                // asserted a few lines above. This message is never the first message being
+                // enqueued in this queue.
+                return TRUE;
+            }
+            else
+            {
+                // Not enough free tail space.
+                return FALSE;
+            }
+        }
+    }
+    else // queue->tail > queue->head
+    {
+        //
+        // The queue looks roughly like this:
+        //
+        // +------+ -----+-----------------+------+------+------+
+        // | msg4 | msg5 | free tail space | msg1 | msg2 | msg3 |
+        // +------+------------------------+------+------+------+
+        //               ^                 ^
+        //             head              tail
+        //
+
+        int free_space_between_head_and_tail = queue->tail - queue->head;
+
+        if (free_space_between_head_and_tail >= total_length)
+        {
+            *(int *)queue->data = length;
+            memory_copy(queue->data + sizeof(int), message, length);
+
+            queue->head += total_length;
+
+            // No need to check if queue->tail is NULL at this stage since it's already been
+            // asserted a few lines above. This message is never the first message being
+            // enqueued in this queue.
+            return TRUE;
+        }
+        else
+        {
+            // Not enough free tail space.
+            return FALSE;
+        }
+
+        return FALSE;
+    }
+}
+
+void *circular_queue_dequeue(circular_queue_type *queue)
+{
+    if (queue->tail == NULL)
+    {
+        // There are no messages in this queue at the moment.
+        return NULL;
+    }
+
+    int length = *(int *)queue->tail;
+    void *result = queue->tail + sizeof(int);
+
+    if (length > queue->size)
+    {
+        // The message in the queue is corrupted; the length of an individual message can never
+        // exceed the whole queue size. Indicate this to the caller.
+        return NULL;
+    }
+
+    queue->tail += length + sizeof(int);
+
+    if (queue->tail >= queue->data_end)
+    {
+        // We have reached the end of the buffer; move the pointer back to the very start of it.
+        queue->tail = queue->data;
+    }
+
+    if (queue->tail == queue->head)
+    {
+        // We have reached the head => there are no more messages waiting in the queue. Update the
+        // tail pointer accordingly.
+        queue->tail = NULL;
+
+        // We can also reset the head to the beginning of the buffer, to simplify the
+        // enqueueing logic.
+        queue->head = queue->data;
+    }
+
+    return result;
+}
+
+int circular_queue_peek(circular_queue_type *queue)
+{
+    if (queue->tail == NULL)
+    {
+        // There are no messages in this queue at the moment.
+        return -1;
+    }
+
+    int length = *(int *)queue->tail;
+
+    return length;
+}
+
+int circular_queue_get_maximum_enqueue_size(circular_queue_type *queue)
+{
+    if (queue->head == queue->tail)
+    {
+        // The head has reached the tail. There is absolutely no free space in this queue.
+        return 0;
+    }
+
+    if (queue->head > queue->tail)
+    {
+        //
+        // The queue looks roughly like this:
+        //
+        // +--------------------+------+------+------+-------------------------+
+        // | free tail space    | msg1 | msg2 | msg3 | free head space         |
+        // +--------------------+------+------+------+-------------------------+
+        //                      ^                    ^
+        //                    tail                  head
+        //
+        // Note: this branch also handles the tail == NULL case. Remember that NULL is just a
+        // convenient alias for 0 in C pointer arithmetics.
+        //
+        int free_space_after_head = queue->data_end - queue->head;
+        int free_space_before_tail = 0;
+
+        if (queue->tail != NULL)
+        {
+            // There is space before the tail, calculate its size.
+            free_space_before_tail = queue->tail - queue->data;
+        }
+
+        return MAX_OF_TWO(free_space_after_head, free_space_before_tail);
+    }
+    else // queue->tail > queue->head
+    {
+        //
+        // The queue looks roughly like this:
+        //
+        // +------+ -----+-----------------+------+------+------+
+        // | msg4 | msg5 | free tail space | msg1 | msg2 | msg3 |
+        // +------+------------------------+------+------+------+
+        //               ^                 ^
+        //             head              tail
+        //
+
+        int free_space_between_head_and_tail = queue->tail - queue->head;
+
+        return free_space_between_head_and_tail;
+    }
+}

--- a/storm/include/storm/defines.h
+++ b/storm/include/storm/defines.h
@@ -3,7 +3,7 @@
 //          Henrik Hallin <hal@chaosdev.org>
 //          Anders Öhrt <doa@chaosdev.org>
 //
-// © Copyright 1998-2017 chaos development
+// © Copyright 1998 chaos development
 
 #pragma once
 
@@ -33,7 +33,7 @@
 #define TASK_ID_MAX             (UINT32_MAX)
 #define MAILBOX_ID_NONE         (UINT32_MAX)
 
-// Some sizes.
+// Some sizes. Note that these are in "real" 2^n sizes, not 10^n.
 #define KB                      ((uint32_t) 1024)
 #define MB                      ((uint32_t) 1024 * KB)
 #define GB                      ((uint32_t) 1024 * MB)

--- a/storm/include/storm/generic/circular_queue.h
+++ b/storm/include/storm/generic/circular_queue.h
@@ -1,0 +1,74 @@
+// Abstract: Circular queue implementation
+// Author: Per Lundberg <per@chaosdev.io>
+//
+// © Copyright 1999 chaos development
+
+#include <storm/generic/types.h>
+
+#pragma once
+
+//
+// Data types
+//
+
+//
+// The implementation talks about "message" as a term for an individual element of the queue, as
+// a convention.
+//
+// The approximate format of the circular queue is as below:
+//
+// +--------------------+------+------+------+-------------------------+
+// | free tail space    | msg1 | msg2 | msg3 | free head space         |
+// +--------------------+------+------+------+-------------------------+
+//                      ^                    ^
+//                    tail                  head
+//
+// For simplicity, a message will never be split between the tail & head
+// space; the head space is first attempted, but if not enough space
+// is available the, the enqueueing code tries to
+typedef struct
+{
+    // This will always point to the next element that should be dequeued. When the queue is empty,
+    // this will be NULL.
+    uint8_t *tail;
+
+    // The will always point to the next location where an element should be enqueued. Note that
+    // because the queue is circular, this could be both before or after `tail`
+    uint8_t *head;
+
+    // The size of the `data` buffer (in bytes)
+    int size;
+
+    // A pointer to the byte right after the end of data[] array, for easy comparison and
+    // debugging purposes. Note that this byte can NOT be written to, since it's one byte past
+    // the allocated buffer.
+    uint8_t *data_end;
+
+    // The buffer holds the messages which are currently placed in the queue.
+    uint8_t data[0];
+} circular_queue_type;
+
+//
+// Function prototypes
+//
+// Initializes a circular queue. Note that `queue_size` given here is the total size of the queue,
+// include the header in `circular_queue_type`; it does not refer to the size of the data buffer
+// which is slightly smaller.
+extern void circular_queue_initialize(circular_queue_type *queue, int queue_size);
+
+// Enqueues a message
+extern bool circular_queue_enqueue(circular_queue_type *queue, void *message, int length);
+
+// Dequeues a message. Note that the message is not copied; a pointer is returned which points
+// into the buffer owned by the circular queue. It will not necessary be valid after the next
+// operation on the queue. It is the callers responsibility to copy the message to a privately
+// owned buffer if necessary.
+extern void *circular_queue_dequeue(circular_queue_type *queue);
+
+// Checks if there are any messages in the queue without modifying the state of the queue. Returns
+// the size of the next message to be dequeued (which can be 0 for empty messages), or -1 if there
+// are no messages available in the queue.
+extern int circular_queue_peek(circular_queue_type *queue);
+
+// Gets the size of the largest message that would fit in the queue currently.
+extern int circular_queue_get_maximum_enqueue_size(circular_queue_type *queue);

--- a/storm/include/storm/x86/memory.h
+++ b/storm/include/storm/x86/memory.h
@@ -1,7 +1,7 @@
 // Abstract: Functions for memory operations.
 // Author: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 1999-2000, 2013 chaos development.
+// © Copyright 1999 chaos development
 
 #pragma once
 

--- a/storm_tests/Rakefile
+++ b/storm_tests/Rakefile
@@ -3,6 +3,7 @@
 Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.options.rakelib.first == 'rakelib'
 
 subfolders = %w[
+  generic
   x86
 ]
 
@@ -29,3 +30,6 @@ task :tests do
     sh "cd #{folder} && #{RAKE_COMMAND} tests"
   end
 end
+
+# No-op, just to not interfere with top-level Rakefile
+task :install

--- a/storm_tests/generic/Rakefile
+++ b/storm_tests/generic/Rakefile
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+OBJECTS = %w[
+  circular_queue_test.o
+  generic_tests_main.o
+].freeze
+
+OUTPUT = :generic_tests
+
+# CFLAGS are set in storm_tests.rake
+
+# All functions overridden by tests must explicitly be listed here, to let the linker redirect
+# the function calls to the wrappers instead of the real implementations.
+#
+# Like this: -Wl,--wrap=memory_global_allocate
+LDFLAGS = %w[
+  -m32
+  -L/usr/local/lib
+  -L../../storm/generic
+  -L../../storm/x86
+].freeze
+
+# Yes, the storm_* actually need to be specified this many times.
+# Without it, GNU ld fails to figure out how to link the tests together.
+LIBRARIES = %w[
+  cmocka
+
+  storm_x86
+  storm_generic
+  storm_x86
+  storm_generic
+  storm_x86
+].freeze
+
+task default: [:banner, OUTPUT]
+
+task :banner do
+  print 'Compiling '.bold
+  print 'storm_tests/generic'.cyan.bold
+  puts '...'
+
+  print '    '
+end
+
+file OUTPUT => OBJECTS + ['../../storm/generic/libstorm_generic.a', '../../storm/x86/libstorm_x86.a'] do |t|
+  begin
+    puts
+    puts
+    puts '    Linking...'.blue.bold
+
+    inputs = OBJECTS.join(' ')
+    command = " \
+      #{CC} -o #{t.name} #{inputs} \
+      #{LDFLAGS.join(' ')} -l#{LIBRARIES.join(' -l')}"
+    sh command
+  rescue StandardError
+    puts "Error linking kernel. Full command line was: #{command}"
+    raise
+  end
+end
+
+task :test do
+  puts
+  run_test OUTPUT
+end
+
+# TODO: Check if we can get Rake's automatic 'clean' support working, so we don't have to do this manually.
+task :clean do
+  rm_f OBJECTS
+  rm_f OUTPUT.to_s
+end
+
+load '../storm_tests.rake'

--- a/storm_tests/generic/circular_queue_test.c
+++ b/storm_tests/generic/circular_queue_test.c
@@ -1,0 +1,151 @@
+// Abstract: Tests for circular_queue.c
+// Authors: Per Lundberg <per@chaosdev.io>
+//
+// © Copyright 1999 chaos development
+
+#include "../test_helper.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <storm/generic/circular_queue.h>
+#include <storm/generic/defines.h>
+
+#define QUEUE_SIZE      64 * KB
+#define MESSAGE_SIZE    100
+
+typedef struct
+{
+    void *message;
+    circular_queue_type *queue;
+} circular_queue_test_type;
+
+int circular_queue_test_setup(void **state)
+{
+    circular_queue_test_type *circular_queue_test = malloc(sizeof(circular_queue_test_type));
+
+    circular_queue_test->message = malloc(MESSAGE_SIZE);
+    memset(circular_queue_test->message, 42, MESSAGE_SIZE);
+
+    circular_queue_test->queue = malloc(QUEUE_SIZE);
+    circular_queue_initialize(circular_queue_test->queue, QUEUE_SIZE);
+
+    *state = circular_queue_test;
+
+    return 0;
+}
+
+void test_circular_queue_enqueue_one(void **state)
+{
+    // Arrange
+    circular_queue_test_type *circular_queue_test = (circular_queue_test_type *) *state;
+    circular_queue_type *queue = circular_queue_test->queue;
+    void *message = circular_queue_test->message;
+
+    // Act
+    //
+    // Deliberately publish only half the message, to avoid all tests being too similar.
+    bool result = circular_queue_enqueue(queue, message, 50);
+
+    // Assert
+    //
+    // The queue holds a size pointer right before each message, which is why the head is now
+    // expected to be 50 + sizeof(int) bytes inside the array.
+    assert_true(result);
+    assert_ptr_equal(queue->head, queue->data + 50 + sizeof(int));
+}
+
+void test_circular_queue_enqueue_until_full(void **state)
+{
+    // Arrange
+    circular_queue_test_type *circular_queue_test = (circular_queue_test_type *) *state;
+    circular_queue_type *queue = circular_queue_test->queue;
+    void *message = circular_queue_test->message;
+
+    // Act & Assert
+    //
+    // The circular queue is 64 KiB, so in total there should is room for (65536 - 16) / 104 = 630
+    // messages of this size.
+    for (int i = 0; i < 630; i++)
+    {
+        assert_true(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+    }
+
+    // Since there are only ~20 bytes left in the buffer at this stage (36 - the size of the fields
+    // in the circular_queue_type), enqueueing this message is expected to fail.
+    assert_false(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+}
+
+void test_circular_queue_enqueue_before_tail(void **state)
+{
+    // Arrange
+    circular_queue_test_type *circular_queue_test = (circular_queue_test_type *) *state;
+    circular_queue_type *queue = circular_queue_test->queue;
+    void *message = circular_queue_test->message;
+
+    // Act & Assert
+    //
+    // Like in the test above, this should succeed.
+    for (int i = 0; i < 630; i++)
+    {
+        assert_true(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+    }
+
+    void *dequeued_message = circular_queue_dequeue(queue);
+    assert_ptr_not_equal(dequeued_message, NULL);
+
+    // There should now be room before the tail, like this:
+    //
+    //   +-----------------+------+------+------+------+-----+--------+
+    //   | free tail space | msg2 | msg3 | msg4 | msg5 | ... | msg630 |
+    //   +-----------------+------+------+------+------+-----+--------+
+    //   ^                 ^
+    // head              tail
+
+    assert_true(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+}
+
+void test_circular_queue_enqueue_between_head_and_tail(void **state)
+{
+    // Arrange
+    circular_queue_test_type *circular_queue_test = (circular_queue_test_type *) *state;
+    circular_queue_type *queue = circular_queue_test->queue;
+    void *message = circular_queue_test->message;
+
+    // Act & Assert
+    //
+    // Like in the test above, this should succeed.
+    for (int i = 0; i < 630; i++)
+    {
+        assert_true(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+    }
+
+    void *dequeued_message = circular_queue_dequeue(queue);
+    assert_ptr_not_equal(dequeued_message, NULL);
+
+    dequeued_message = circular_queue_dequeue(queue);
+    assert_ptr_not_equal(dequeued_message, NULL);
+
+    dequeued_message = circular_queue_dequeue(queue);
+    assert_ptr_not_equal(dequeued_message, NULL);
+
+    // There should now be room before the tail, like this:
+    //
+    //   +-----------------+------+------+------+------+-----+--------+
+    //   | free tail space | msg4 | msg5 | msg6 | msg7 | ... | msg630 |
+    //   +-----------------+------+------+------+------+-----+--------+
+    //   ^                 ^
+    // head              tail
+    //
+    // The point of this test is to ensure that the free tail space can be used up in full; the
+    // test_circular_queue_enqueue_before_tail() only attempts to enqueue a single message into
+    // the free tail space while this test enqueues multiple ones. So this can be considered a
+    // superset of test_circular_queue_enqueue_before_tail()
+
+    assert_true(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+    assert_true(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+    assert_true(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+
+    // The queue is now expected to be full.
+    assert_false(circular_queue_enqueue(queue, message, MESSAGE_SIZE));
+}

--- a/storm_tests/generic/generic_tests_main.c
+++ b/storm_tests/generic/generic_tests_main.c
@@ -1,0 +1,26 @@
+// Abstract: Entry point for the unit test program.
+// Authors: Per Lundberg <per@chaosdev.io>
+//
+// © Copyright 1999 chaos development
+
+#include "../test_helper.h"
+
+extern int circular_queue_test_setup(void **state);
+
+extern void test_circular_queue_enqueue_one(void **state);
+extern void test_circular_queue_enqueue_until_full(void **state);
+extern void test_circular_queue_enqueue_before_tail(void **state);
+extern void test_circular_queue_enqueue_between_head_and_tail(void **state);
+
+int main(void)
+{
+    const struct CMUnitTest mailbox_tests[] =
+    {
+        cmocka_unit_test_setup(test_circular_queue_enqueue_one, circular_queue_test_setup),
+        cmocka_unit_test_setup(test_circular_queue_enqueue_until_full, circular_queue_test_setup),
+        cmocka_unit_test_setup(test_circular_queue_enqueue_before_tail, circular_queue_test_setup),
+        cmocka_unit_test_setup(test_circular_queue_enqueue_between_head_and_tail, circular_queue_test_setup)
+    };
+
+    cmocka_run_group_tests_name("circular_queue", mailbox_tests, NULL, NULL);
+}

--- a/storm_tests/storm_tests.rake
+++ b/storm_tests/storm_tests.rake
@@ -2,8 +2,11 @@
 
 Rake.application.options.rakelib = ["#{File.dirname(__FILE__)}/../rakelib"] if Rake.application.options.rakelib.first == 'rakelib'
 
+# For a saner gdb experience, you typically want to compile without optimizations unless specifically making a release.
+OPTIMIZATION_FLAG = ENV['RELEASE'] ? '-O3' : '-O0'
+
 # FIXME: Don't repeat all of these in many places.
-COMMON_CFLAGS = %w[
+COMMON_CFLAGS = %W[
   -Wall
   -Wextra
   -Wshadow
@@ -17,8 +20,9 @@ COMMON_CFLAGS = %w[
   -Wmissing-declarations
   -Wmissing-noreturn
   -pipe
-  -O3
+  #{OPTIMIZATION_FLAG}
   -funsigned-char
+  -g
   -m32
   -fomit-frame-pointer
 ].freeze
@@ -33,7 +37,6 @@ CFLAGS = COMMON_CFLAGS + %w[
 ]
 
 INCLUDES = %w[
-  -I..
   -I../../storm/include
 ].freeze
 

--- a/storm_tests/test_helper.h
+++ b/storm_tests/test_helper.h
@@ -8,6 +8,7 @@
 // Standard headers needed by cmocka
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 
 #include <cmocka.h>

--- a/storm_tests/x86/memory_global_test.c
+++ b/storm_tests/x86/memory_global_test.c
@@ -3,9 +3,10 @@
 //
 // © Copyright 2015-2016 chaos development
 
-#include "test_helper.h"
+#include "../test_helper.h"
 
 #include <stdlib.h>
+
 #include <storm/generic/memory_global.h>
 #include <storm/generic/return_values.h>
 
@@ -14,7 +15,7 @@ return_type memory_physical_allocate(uint32_t *page, unsigned int length, char *
     void *p;
     int return_value = posix_memalign(&p, SIZE_PAGE, SIZE_PAGE * length);
     assert_int_equal(return_value, 0);
-    
+
     return RETURN_SUCCESS;
 }
 

--- a/storm_tests/x86/string_tests.c
+++ b/storm_tests/x86/string_tests.c
@@ -1,9 +1,9 @@
 // Abstract: String routines (unit tests)
 // Authors: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 2015-2016 chaos development
+// © Copyright 2015 chaos development
 
-#include "test_helper.h"
+#include "../test_helper.h"
 
 #include <storm/generic/string.h>
 

--- a/storm_tests/x86/x86_tests_main.c
+++ b/storm_tests/x86/x86_tests_main.c
@@ -1,9 +1,9 @@
 // Abstract: Entry point for the unit test program.
 // Authors: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 2015-2016 chaos development
+// © Copyright 2015 chaos development
 
-#include "test_helper.h"
+#include "../test_helper.h"
 
 extern void test_memory_global_allocate(void **state);
 extern void test_memory_global_deallocate(void **state);
@@ -29,7 +29,7 @@ int main(void)
         cmocka_unit_test(string_to_number_hexadecimal),
         cmocka_unit_test(string_to_number_binary)
     };
-    
+
     cmocka_run_group_tests_name("memory_global", memory_global_tests, NULL, NULL);
     cmocka_run_group_tests_name("string", string_tests, NULL, NULL);
 }


### PR DESCRIPTION
This was a rather complex change which was discussed with @doverhill on Slack a bit. Because our memory allocation tend to degenerate over time, we looked into other ways of handling the IPC than the previous approach (which would incur a memory allocation and deallocation for _every single message_ being posted via the IPC mechanism)

The new approach uses a circular queue, which was written in an isolated and reusable way, completely separate from the mailbox code. This means that `mailbox_send` and `mailbox_receive` got a whole lot more readable in the process, as an added bonus.

The implementation was greatly helped by the fact that we could unit test the circular queue in isolation, in VS Code on Linux (with full `gdb` debugger support). This was an _incredible_ help in getting this done with a reasonable level of effort.

Kernel development has never felt this "easy" before, relatively speaking. I still ran into a bug (in `mailbox_receive`) but it was literally a 10-minute fix. After it was done, the system would boot up
correctly again, which felt really nice.