### PR TITLE
[servers/soundblaster] Use "generic DMA" command for starting playback

### DIFF
--- a/libraries/sound/types.h
+++ b/libraries/sound/types.h
@@ -1,40 +1,21 @@
-/* Abstract: Types used by the sound library. */
-/* Author: Erik Moren <nemo@chaosdev.org> */
+// Abstract: Types used by the sound library.
+// Author: Erik Moren <nemo@chaosdev.org>
 
-/* Copyright 2000 chaos development. */
+// © Copyright 1999 chaos development
 
-/* This library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public License
-   as published by the Free Software Foundation; either version 2 of
-   the License, or (at your option) any later version.
+#pragma once
 
-   This library is distributed in the hope that it will be useful, but
-   WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Lesser General Public License for more details.
-
-   You should have received a copy of the GNU Lesser General Public
-   License along with this library; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-   USA. */
-
-#ifndef __LIBRARY_SOUND_TYPES_H__
-#define __LIBRARY_SOUND_TYPES_H__
-
-/* FIXME: Sound message structure. */
-
+// FIXME: Sound message structure.
 typedef struct
 {
-  unsigned int frequency;
-  unsigned int bits;
+    unsigned int frequency;
+    unsigned int bits;
 
-  /* This is the size of the next sample played, or the size of the
-     buffers used when streaming data */
-  unsigned int length;
+    // This is the size of the next sample played, or the size of the
+    // buffers used when streaming data */
+    unsigned int length;
 
-  /* A pointer to the data sent */
-  uint8_t data[0];
-
+    // An array of the data sent. The actual size of this will be
+    // `length` bytes.
+    uint8_t data[0];
 } __attribute__ ((packed)) sound_message_type;
-
-#endif /* !__LIBRARY_SOUND_TYPES_H__ */

--- a/programs/modplay/modplay.c
+++ b/programs/modplay/modplay.c
@@ -139,7 +139,8 @@ int main(void)
         //   The optional trkbuf parameter can be used to get detailed status of the player. Put NULL/0 is unused.
 
         trackbuf_state.nb_of_state = 0;
-        hxcmod_fillbuffer(&modctx, sound_message->data, NUMBER_OF_SAMPLES, &trackbuf_state);
+        hxcmod_fillbuffer(&modctx, (uint8_t *) sound_message->data,
+                          NUMBER_OF_SAMPLES, &trackbuf_state);
 
         if (sound_play_stream(&ipc_structure, sound_message) !=
                 SOUND_RETURN_SUCCESS)

--- a/programs/modplay/modplay.h
+++ b/programs/modplay/modplay.h
@@ -7,8 +7,8 @@
 
 // The number of samples per buffer.
 #define NUMBER_OF_SAMPLES   2000
-#define NUM_CHANNELS        1      // 1 = mono, 2 = stereo
-#define BYTES_PER_SAMPLE    1  // 1 = 8-bit, 2 = 16-bit
+#define NUM_CHANNELS        1       // 1 = mono, 2 = stereo
+#define BYTES_PER_SAMPLE    1       // 1 = 8-bit, 2 = 16-bit
 #define BUFFER_SIZE         (NUMBER_OF_SAMPLES * NUM_CHANNELS * BYTES_PER_SAMPLE)
 
 // Note: hxcmod_setcfg must be called if you wish to use something different than this.

--- a/servers/sound/soundblaster/soundblaster.h
+++ b/servers/sound/soundblaster/soundblaster.h
@@ -15,7 +15,8 @@
 #define DSP_RESET                       (base_port + 0x06)
 #define DSP_DATA_READ                   (base_port + 0x0A)
 #define DSP_DATA_WRITE                  (base_port + 0x0C)
-#define DSP_DATA_AVAILABLE              (base_port + 0x0E)
+#define DSP_DATA_AVAILABLE_8BIT         (base_port + 0x0E)
+#define DSP_DATA_AVAILABLE_16BIT        (base_port + 0x0F)
 
 // Commands (sent to DSP_DATA_WRITE).
 #define DSP_VERSION                     (0xE1)
@@ -28,6 +29,10 @@
 #define DSP_MODE_DMA_8BIT_ADC           (0x24)
 #define DSP_SET_TIME_CONSTANT           (0x40)
 #define DSP_SET_DMA_BLOCK_SIZE          (0x48)
+
+#define DSP_GENERIC_DMA_8BIT_AUTOINIT_DAC   (0xC6)
+#define DSP_GENERIC_DMA_16BIT_DAC           (0xB0)
+#define DSP_GENERIC_DMA_16BIT_AUTOINIT_DAC  (0xB6)
 
 typedef struct
 {

--- a/servers/video/vga/vga.c
+++ b/servers/video/vga/vga.c
@@ -2,9 +2,7 @@
 // Authors: Per Lundberg <per@chaosdev.io>
 //          Henrik Hallin <hal@chaosdev.org>
 //
-// © Copyright 1999-2000 chaos development
-// © Copyright 2013 chaos development
-// © Copyright 2015-2016 chaos development
+// © Copyright 1999
 
 #include <console/console.h>
 #include <ipc/ipc.h>


### PR DESCRIPTION
We previously used a very specific DSP command which is limited to 8-bit. This change still does not support 16-bit, but it at least moves to the form of the commands which can _potentially_ support 16-bit, so it's a step in the right direction.

(The "generic" DSP commands only work on SB16 and newer, which is completely fine since we've never even claimed to properly support SB 2.0 anyway. :) )

## Why not 16-bit playback?

I am yet to get 16-bit (mono) playback working, which _should_ be trivial but... for whatever reason, I never get any sound when I try with the diff below. Highly annoying. I also tried enabling the stereo flag but it didn't make any difference.

Maybe reading the [DevSB16.cpp source code](https://www.virtualbox.org/browser/vbox/trunk/src/VBox/Devices/Audio/DevSB16.cpp) in the VirtualBox source code would help us understand why this happens. For now, still only 8-bit.

Getting 8-bit stereo working should be easy though (I already tried enabling the stereo flag in 8-bit mode and it plays the mono sound at twice the speed ;) so that should be pretty much a walk in the park.

```diff
diff --git a/servers/sound/soundblaster/soundblaster.c b/servers/sound/soundblaster/soundblaster.c
index c1f2b59..9c65ec6 100644
--- a/servers/sound/soundblaster/soundblaster.c
+++ b/servers/sound/soundblaster/soundblaster.c
@@ -253,7 +253,7 @@ void irq_handler(irq_handler_data_type *irq_handler_data)
         log_print(&log_structure, LOG_URGENCY_DEBUG, "Received hardware interrupt");
 
         // Acknowledge the SB interrupt.
-        system_port_in_uint8_t(DSP_DATA_AVAILABLE_8BIT);
+        system_port_in_uint8_t(DSP_DATA_AVAILABLE_16BIT);
 
         // Send an acknowledgement message to the client program.
         message_parameter.protocol = IPC_PROTOCOL_NONE;
@@ -443,7 +443,7 @@ void handle_connection(mailbox_id_type reply_mailbox_id)
 
                         // Enable 8-bit auto-initializing DMA-based playing. See sblaster.doc for
                         // more details (0Bxh/0Cxh  Generic DAC/ADC DMA)
-                        dsp_write(DSP_GENERIC_DMA_8BIT_AUTOINIT_DAC);
+                        dsp_write(DSP_GENERIC_DMA_16BIT_AUTOINIT_DAC);
                         dsp_write(0); // Bit 5 = stereo, bit 4 = signed. 0 means "mono, unsigned"
                         dsp_write((uint8_t) length);
                         dsp_write((uint8_t)(length >> 8));
```