### PR TITLE
(pci) Include vendor and device ID in pci_device_info_type

### DIFF
--- a/libraries/ipc/pci.h
+++ b/libraries/ipc/pci.h
@@ -1,8 +1,7 @@
 // Abstract: Protocol for communicating with the PCI server.
 // Author: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 1999-2000 chaos development
-// © Copyright 2013-2017 chaos development
+// © Copyright 1999 chaos development
 
 #pragma once
 
@@ -84,5 +83,7 @@ typedef struct
 typedef struct
 {
     unsigned int irq;
+    uint16_t vendor_id;
+    uint16_t device_id;
     pci_resource_type resource[PCI_NUMBER_OF_RESOURCES];
 } pci_device_info_type;

--- a/libraries/pci/functions.h
+++ b/libraries/pci/functions.h
@@ -1,8 +1,7 @@
 // Abstract: PCI library function prototypes.
 // Author: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 2000 chaos development
-// © Copyright 2015-2016 chaos development
+// © Copyright 1999 chaos development
 
 #pragma once
 

--- a/libraries/pci/pci.h
+++ b/libraries/pci/pci.h
@@ -1,8 +1,7 @@
 // Abstract: PCI library header file.
 // Author: Per Lundberg <per@chaosdev.io>
 //
-// © Copyright 2000 chaos development
-// © Copyright 2015-2016 chaos development
+// © Copyright 1999 chaos development
 
 #pragma once
 

--- a/servers/system/pci/pci.c
+++ b/servers/system/pci/pci.c
@@ -223,7 +223,8 @@ static void handle_connection(mailbox_id_type *reply_mailbox_id)
 
                 while (device != NULL)
                 {
-                    if (probe->vendor_id == device->vendor_id && probe->device_id == device->device_id)
+                    if (probe->vendor_id == device->vendor_id &&
+                        probe->device_id == device->device_id)
                     {
                         devices++;
                     }
@@ -238,7 +239,8 @@ static void handle_connection(mailbox_id_type *reply_mailbox_id)
 
                 while (device != NULL && counter < devices)
                 {
-                    if (probe->vendor_id == device->vendor_id && probe->device_id == device->device_id)
+                    if (probe->vendor_id == device->vendor_id &&
+                        probe->device_id == device->device_id)
                     {
                         memory_copy(&device_info[counter].resource, device->resource,
                                     sizeof(pci_resource_type) * PCI_NUMBER_OF_RESOURCES);
@@ -246,6 +248,8 @@ static void handle_connection(mailbox_id_type *reply_mailbox_id)
                     }
 
                     device_info->irq = device->irq;
+                    device_info->vendor_id = device->vendor_id;
+                    device_info->device_id = device->device_id;
 
                     device = (pci_device_type *) device->next;
                 }


### PR DESCRIPTION
The use case is this: For device drivers which supports multiple PCI device ID:s, it is sometimes important to be able to differentiate minor details in the hardware-related code depending on device ID. For example, the EEPROM of a network card might be read using slightly different mechanisms on different device ID:s, whereas the rest of the hardware support (PHY etc) is entirely identical.

So, to be able to better support such use cases, we are now adding a few fields to the pci_device_info_type, which is used when probing for PCI devices.