### PR TITLE
(cluido) Fix command_execute to support a hardwired PATH

### DIFF
--- a/programs/cluido/cluido.c
+++ b/programs/cluido/cluido.c
@@ -707,11 +707,20 @@ void run(char *command_string)
             }
         }
 
-        // If this command does not exist, tell the user politely so.
+        // If this is not a valid internal command, try running it as an external command instead.
+        // TODO: Take the rest of the parsed arguments and pass it to command_execute as well.
+        // That method does not support argument-passing to the program being started at the moment
+        // anyway, but if/when that is fixed, we need to revisit this as well.
         if (counter == number_of_commands)
         {
+            char *command_arguments[2] =
+            {
+                "execute",
+                first_word
+            };
+
             prompt_print(environment_get("prefix"));
-            console_print(&console_structure, "Unknown command. Try '?' or 'help' for help.\n");
+            command_execute(2, command_arguments);
             prompt_print(environment_get("postfix"));
         }
     }

--- a/programs/cluido/cluido.h
+++ b/programs/cluido/cluido.h
@@ -12,6 +12,7 @@ extern void main_loop(void) __attribute__((noreturn));
 extern void prompt_print(char *input);
 extern char *environment_get(char *key);
 extern void run(char *command_string);
+extern void command_execute(int number_of_arguments, char **argument);
 
 // Type definitions.
 typedef struct


### PR DESCRIPTION
Also fixed the command running to delegate to command_execute for all unknown commands. This means we can finally type just `modplay` to start the modplayer; the extra ceremony of `execute //ramdisk/programs/modplay` is now a thing of the past.