### PR TITLE
(storm) Fix debug_print() handling of large unsigned integers

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,26 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceRoot}",
+                "${workspaceRoot}/libraries",
+                "${workspaceRoot}/storm/include",
+                "/usr/local/include",
+                "."
+            ],
+            "defines": [
+                "__i386__"
+            ],
+            "intelliSenseMode": "clang-x64",
+            "browse": {
+                "path": [
+                    "${workspaceRoot}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            }
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,50 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "storm tests (generic)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/storm_tests/generic/generic_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build_tests",
+            "miDebuggerPath": "/usr/bin/gdb"
+        },
+        {
+            "name": "storm tests (x86)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/storm_tests/x86/x86_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build_tests",
+            "miDebuggerPath": "/usr/bin/gdb"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,37 @@
+{
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "gcc-7 build active file",
+            "command": "/usr/bin/gcc-7",
+            "args": [
+                "-g",
+                "${file}",
+                "-o",
+                "${fileDirname}/${fileBasenameNoExtension}"
+            ],
+            "options": {
+                "cwd": "/usr/bin"
+            }
+        },
+        {
+            "label": "build_tests",
+            "type": "shell",
+            "command": "rake",
+            "args": [
+                "default",
+                "build_storm_tests"
+            ],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher":"$gcc"
+        }
+    ],
+    "version": "2.0.0"
+}

--- a/storm/generic/debug.c
+++ b/storm/generic/debug.c
@@ -343,8 +343,8 @@ void debug_print_simple(const char *string)
     //  cpu_interrupts_enable ();
 }
 
-// Convert a decimal number to a string.
-static void decimal_string(char *string, int number)
+// Converts a number to a string (decimal representation)
+void decimal_string(char *string, unsigned int number)
 {
     int index = 0;
     const char decimal[] = "0123456789";

--- a/storm/include/storm/x86/debug.h
+++ b/storm/include/storm/x86/debug.h
@@ -1,9 +1,7 @@
 // Abstract: ia32 specific debug functions.
 // Author: Per Lundberg <per@chaosdev.io>
 
-// © Copyright 2000 chaos development.
-// © Copyright 2007 chaos development.
-// © Copyright 2015-2016 chaos development.
+// © Copyright 1999 chaos development.
 
 #pragma once
 
@@ -13,3 +11,4 @@
 
 extern void debug_dump_descriptor(descriptor_type *desc);
 extern void debug_memory_dump(uint32_t *memory, uint32_t length);
+extern void decimal_string(char *string, unsigned int number);

--- a/storm_tests/x86/Rakefile
+++ b/storm_tests/x86/Rakefile
@@ -15,10 +15,12 @@ LDFLAGS = %w[
   -L../../storm/x86
 ].freeze
 
-# Need to provide the same name twice for linking to succeed. (circular dependency?)
+# Need to provide the same name multiple times for linking to succeed. (circular dependencies?)
 LIBRARIES = %w[
   cmocka
 
+  storm_x86
+  storm_generic
   storm_x86
   storm_generic
   storm_x86

--- a/storm_tests/x86/string_tests.c
+++ b/storm_tests/x86/string_tests.c
@@ -6,6 +6,7 @@
 #include "../test_helper.h"
 
 #include <storm/generic/string.h>
+#include <storm/current-arch/debug.h>
 
 void string_to_number_decimal(void **state)
 {
@@ -45,4 +46,13 @@ void string_to_number_binary(void **state)
     string_to_number("0b00101010", &i);
 
     assert_int_equal(i, 42);
+}
+
+void decimal_string_high_value(void **state)
+{
+    unsigned int i = 4294967272;
+    char s[11];
+
+    decimal_string(s, i);
+    assert_string_equal(s, "4294967272");
 }

--- a/storm_tests/x86/x86_tests_main.c
+++ b/storm_tests/x86/x86_tests_main.c
@@ -12,6 +12,7 @@ extern void string_to_number_negative_decimal(void **state);
 extern void string_to_number_invalid_value(void **state);
 extern void string_to_number_hexadecimal(void **state);
 extern void string_to_number_binary(void **state);
+extern void decimal_string_high_value(void **state);
 
 int main(void)
 {
@@ -27,7 +28,8 @@ int main(void)
         cmocka_unit_test(string_to_number_negative_decimal),
         cmocka_unit_test(string_to_number_invalid_value),
         cmocka_unit_test(string_to_number_hexadecimal),
-        cmocka_unit_test(string_to_number_binary)
+        cmocka_unit_test(string_to_number_binary),
+        cmocka_unit_test(decimal_string_high_value)
     };
 
     cmocka_run_group_tests_name("memory_global", memory_global_tests, NULL, NULL);


### PR DESCRIPTION
The problem was that the `decimal_string()` helper method being used would take a signed integer as a parameter, which made it impossible to print integers with bit 31 set (since this is the sign bit in
two's complement representation of signed numbers).

Being able to use unit tests for this made the debugging experience short and sweet, just like it ought to be. Adding VSCode configs for this, since I noted they were not present in the repo.