### PR TITLE
(vscode) Add storm remote debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,6 +45,19 @@
             ],
             "preLaunchTask": "build_tests",
             "miDebuggerPath": "/usr/bin/gdb"
+        },
+        {
+            "name": "Remote debug in qemu (storm)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/storm/x86/storm",
+            "miDebuggerServerAddress": "localhost:1234",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}",
+            "environment": [],
+            "externalConsole": true,
+            "MIMode": "gdb"
         }
     ]
 }


### PR DESCRIPTION
This makes it insanely easy to remote-debug storm in a local qemu:

- Compile the chaos code: `rake install`
- Start qemu: `./qemu.sh`. This script has gdb remote-debugging enabled on port 1234.
- Select the configuration in VSCode and press the Play button.

You should now be able to set breakpoints, step through code etc, just
as if the program was running on your Linux host. Very useful.

Here is what it looks like in action:

![image](https://user-images.githubusercontent.com/630613/63975410-a8b87e80-cab7-11e9-9583-f45728286060.png)
