### PR TITLE
Update to Debian 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To build the system from source, use the following approach. (Requires Vagrant a
 
 ```shell
 $ git clone ... && cd chaos
-$ vagrant up
+$ vagrant up ... (or with libvirt: $ vagrant up --provider libvirt)
 $ vagrant ssh
 $ rake
 $ rake install

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ $ rake install
 
 If all goes well, this should give you an `.iso` file as output. For more details, consult [our web site](https://chaos4ever.github.io).
 
+If you use qemu/rsync with Vagrant, do this in the directory you ran ``vagrant up`` from:
+```
+$ vagrant ssh-config > ssh_config
+$ rsync -avH -e "ssh -F ./ssh_config" default:/vagrant/ ./
+```
+Source: [https://serverfault.com/questions/699160/copy-files-from-guest-to-host-the-first-time-with-rsync-using-vagrant#699498](https://serverfault.com/questions/699160/copy-files-from-guest-to-host-the-first-time-with-rsync-using-vagrant#699498)
+
 ## License
 
 ### General

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,7 @@ Vagrant.configure("2") do |config|
       psmisc \
       qemu \
       gcc-arm-none-eabi \
+      xorriso \
       rake
 
     # The gcc-arm-none-eabi package is not yet available in stretch:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,8 @@ Vagrant.configure("2") do |config|
     # Override sources.list for faster downloads (for people outside of the US).
     echo deb http://httpredir.debian.org/debian/ bullseye main > /etc/apt/sources.list
     echo deb-src http://httpredir.debian.org/debian/ bullseye main >> /etc/apt/sources.list
-    # echo deb http://security.debian.org/debian-security bullseye/updates main >> /etc/apt/sources.list
-    # echo deb-src http://security.debian.org/debian-security bullseye/updates main >> /etc/apt/sources.list
+    echo deb http://security.debian.org/debian-security bullseye-security main >> /etc/apt/sources.list
+    echo deb-src http://security.debian.org/debian-security bullseye-security main >> /etc/apt/sources.list
 
     sudo apt-get update
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -34,12 +34,6 @@ Vagrant.configure("2") do |config|
       gcc-arm-none-eabi \
       xorriso \
       rake
-
-    # The gcc-arm-none-eabi package is not yet available in stretch:
-    # https://packages.debian.org/jessie/devel/gcc-arm-none-eabi
-    #echo deb http://httpredir.debian.org/debian/ unstable main >> /etc/apt/sources.list
-    #sudo apt-get update
-    #sudo DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-arm-none-eabi
 
     # Disabled for now since we don't have any Rust dependencies, and it slows things down when setting the VM up.
     ## We need the beta channel for the #![feature] functionality.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-Vagrant.configure(2) do |config|
-  config.vm.box = 'remram/debian-9-i386'
+Vagrant.configure("2") do |config|
+  config.vm.box = "roboxes-x32/debian11"
 
   # Sometimes, the default seems to be too little for this one.
   config.vm.boot_timeout = 600
-
+  # When using libvirt it's usefull to explicitly tell Vagrant what method
+  # of folder syncing to use.
+  config.vm.synced_folder "./", "/vagrant", type: "rsync"
   config.vm.provision 'shell', inline: <<-SHELL
     set -e
 
     # Override sources.list for faster downloads (for people outside of the US).
-    echo deb http://httpredir.debian.org/debian/ stretch main > /etc/apt/sources.list
-    echo deb-src http://httpredir.debian.org/debian/ stretch main >> /etc/apt/sources.list
-    echo deb http://security.debian.org/debian-security stretch/updates main >> /etc/apt/sources.list
-    echo deb-src http://security.debian.org/debian-security stretch/updates main >> /etc/apt/sources.list
+    echo deb http://httpredir.debian.org/debian/ bullseye main > /etc/apt/sources.list
+    echo deb-src http://httpredir.debian.org/debian/ bullseye main >> /etc/apt/sources.list
+    # echo deb http://security.debian.org/debian-security bullseye/updates main >> /etc/apt/sources.list
+    # echo deb-src http://security.debian.org/debian-security bullseye/updates main >> /etc/apt/sources.list
 
     sudo apt-get update
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -29,13 +31,14 @@ Vagrant.configure(2) do |config|
       nasm \
       psmisc \
       qemu \
+      gcc-arm-none-eabi \
       rake
 
     # The gcc-arm-none-eabi package is not yet available in stretch:
     # https://packages.debian.org/jessie/devel/gcc-arm-none-eabi
-    echo deb http://httpredir.debian.org/debian/ unstable main >> /etc/apt/sources.list
-    sudo apt-get update
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-arm-none-eabi
+    #echo deb http://httpredir.debian.org/debian/ unstable main >> /etc/apt/sources.list
+    #sudo apt-get update
+    #sudo DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-arm-none-eabi
 
     # Disabled for now since we don't have any Rust dependencies, and it slows things down when setting the VM up.
     ## We need the beta channel for the #![feature] functionality.

--- a/programs/Rakefile
+++ b/programs/Rakefile
@@ -4,7 +4,6 @@ Rake.application.options.rakelib = [pwd + '/../rakelib'] if Rake.application.opt
 
 SUBFOLDERS = %w[
   cluido
-  modplay
 ].freeze
 
 # Not yet converted to rake:

--- a/servers/servers.rake
+++ b/servers/servers.rake
@@ -18,6 +18,7 @@ COMMON_CFLAGS = %W[
   -Wredundant-decls
   -Winline
   -Werror
+  -Wno-error=address-of-packed-member
   -Wcast-align
   -Wno-cast-function-type
   -Wno-pointer-sign

--- a/storm/rakelib/storm.rake
+++ b/storm/rakelib/storm.rake
@@ -9,7 +9,7 @@ OPTIMIZATION_FLAG = ENV['RELEASE'] ? '-O3' : '-O0'
 
 COMMON_CFLAGS =
   "-Wall -Wextra -Wshadow -Wpointer-arith -Waggregate-return -Wredundant-decls \
-  -Winline -Werror -Wcast-align -Wsign-compare -Wmissing-declarations \
+  -Winline -Werror -Wno-error=address-of-packed-member -Wcast-align -Wsign-compare -Wmissing-declarations \
   -Wmissing-noreturn -pipe #{OPTIMIZATION_FLAG} -fno-builtin -fno-asynchronous-unwind-tables -funsigned-char \
   -g -fomit-frame-pointer -ffreestanding #{ENV['EXTRA_CFLAGS']} #{DEFINES} ".freeze
 


### PR DESCRIPTION
Update to use Debian 11 to build with Vagrant. This breaks modplay functionality.